### PR TITLE
update samples to contain new supported format for specifying locations

### DIFF
--- a/cosmosdb/create-cosmosdb-account-database/create-cosmosdb-account-database.sh
+++ b/cosmosdb/create-cosmosdb-account-database/create-cosmosdb-account-database.sh
@@ -19,7 +19,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --kind GlobalDocumentDB \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "Session" \
     --enable-multiple-write-locations true
 

--- a/cosmosdb/create-cosmosdb-cassandra-account/create-cosmosdb-cassandra-account.sh
+++ b/cosmosdb/create-cosmosdb-cassandra-account/create-cosmosdb-cassandra-account.sh
@@ -18,7 +18,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --capabilities EnableCassandra \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "ConsistentPrefix" \
     --enable-multiple-write-locations true
 

--- a/cosmosdb/create-cosmosdb-gremlin-account/create-cosmosdb-gremlin-account.sh
+++ b/cosmosdb/create-cosmosdb-gremlin-account/create-cosmosdb-gremlin-account.sh
@@ -19,7 +19,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
 	--name $accountName \
     --capabilities EnableGremlin \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "Session" \
     --enable-multiple-write-locations true
 

--- a/cosmosdb/create-cosmosdb-mongodb-account/create-cosmosdb-mongodb-account.sh
+++ b/cosmosdb/create-cosmosdb-mongodb-account/create-cosmosdb-mongodb-account.sh
@@ -18,7 +18,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --kind MongoDB \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "ConsistentPrefix" \
     --enable-multiple-write-locations true
 

--- a/cosmosdb/create-cosmosdb-table-account/create-cosmosdb-table-account.sh
+++ b/cosmosdb/create-cosmosdb-table-account/create-cosmosdb-table-account.sh
@@ -19,7 +19,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --capabilities EnableTable \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "Session" \
     --enable-multiple-write-locations true
 

--- a/cosmosdb/high-availability-cosmosdb-configure-failover/high-availability-cosmosdb-configure-failover.sh
+++ b/cosmosdb/high-availability-cosmosdb-configure-failover/high-availability-cosmosdb-configure-failover.sh
@@ -17,7 +17,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --kind GlobalDocumentDB \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "Session"
 
 

--- a/cosmosdb/scale-cosmosdb-get-account-key/secure-cosmosdb-get-account-key.sh
+++ b/cosmosdb/scale-cosmosdb-get-account-key/secure-cosmosdb-get-account-key.sh
@@ -16,7 +16,8 @@ az group create \
 az cosmosdb create \
 	--name $accountName \
 	--kind GlobalDocumentDB \
-	--locations "South Central US"=0 "North Central US"=1 \
+	--locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
 	--resource-group $resourceGroupName \
     --default-consistency-level "Session"
 

--- a/cosmosdb/scale-cosmosdb-get-account-key/secure-cosmosdb-get-account-key.sh
+++ b/cosmosdb/scale-cosmosdb-get-account-key/secure-cosmosdb-get-account-key.sh
@@ -17,7 +17,7 @@ az cosmosdb create \
 	--name $accountName \
 	--kind GlobalDocumentDB \
 	--locations regionName="South Central US" failoverPriority=0 \
-    --locations regionName="North Central US" failoverPriority=1 \
+	--locations regionName="North Central US" failoverPriority=1 \
 	--resource-group $resourceGroupName \
     --default-consistency-level "Session"
 

--- a/cosmosdb/scale-cosmosdb-replicate-multiple-regions/scale-cosmosdb-replicate-multiple-regions.sh
+++ b/cosmosdb/scale-cosmosdb-replicate-multiple-regions/scale-cosmosdb-replicate-multiple-regions.sh
@@ -27,7 +27,10 @@ read -p "Press any key to add locations..."
 az cosmosdb update \
 	--name $accountName \
 	--resource-group $resourceGroupName \
-	--locations "South Central US"=0 "North Central US"=1 "East US"=2 "West US"=3
+	--locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
+	--locations regionName="East US" failoverPriority=2 \
+    --locations regionName="West US" failoverPriority=3
 
 
 read -p "Press any key to change failover regions..."
@@ -37,4 +40,7 @@ read -p "Press any key to change failover regions..."
 az cosmosdb update \
 	--name $accountName \
 	--resource-group $resourceGroupName \
-	--locations "South Central US"=3 "North Central US"=2 "East US"=1 "West US"=0
+	--locations regionName="South Central US" failoverPriority=3 \
+    --locations regionName="North Central US" failoverPriority=2 \
+	--locations regionName="East US" failoverPriority=1 \
+    --locations regionName="West US" failoverPriority=0

--- a/cosmosdb/scale-cosmosdb-replicate-multiple-regions/scale-cosmosdb-replicate-multiple-regions.sh
+++ b/cosmosdb/scale-cosmosdb-replicate-multiple-regions/scale-cosmosdb-replicate-multiple-regions.sh
@@ -28,9 +28,9 @@ az cosmosdb update \
 	--name $accountName \
 	--resource-group $resourceGroupName \
 	--locations regionName="South Central US" failoverPriority=0 \
-    --locations regionName="North Central US" failoverPriority=1 \
+	--locations regionName="North Central US" failoverPriority=1 \
 	--locations regionName="East US" failoverPriority=2 \
-    --locations regionName="West US" failoverPriority=3
+	--locations regionName="West US" failoverPriority=3
 
 
 read -p "Press any key to change failover regions..."
@@ -41,6 +41,6 @@ az cosmosdb update \
 	--name $accountName \
 	--resource-group $resourceGroupName \
 	--locations regionName="South Central US" failoverPriority=3 \
-    --locations regionName="North Central US" failoverPriority=2 \
+	--locations regionName="North Central US" failoverPriority=2 \
 	--locations regionName="East US" failoverPriority=1 \
-    --locations regionName="West US" failoverPriority=0
+	--locations regionName="West US" failoverPriority=0

--- a/cosmosdb/scale-cosmosdb-throughput/scale-cosmosdb-throughput.sh
+++ b/cosmosdb/scale-cosmosdb-throughput/scale-cosmosdb-throughput.sh
@@ -21,7 +21,7 @@ az cosmosdb create \
 	--name $accountName \
 	--kind GlobalDocumentDB \
 	--locations regionName="South Central US" failoverPriority=0 \
-    --locations regionName="North Central US" failoverPriority=1 \
+	--locations regionName="North Central US" failoverPriority=1 \
 	--resource-group $resourceGroupName \
 	--default-consistency-level "Session" \
     --enable-multiple-write-locations true

--- a/cosmosdb/scale-cosmosdb-throughput/scale-cosmosdb-throughput.sh
+++ b/cosmosdb/scale-cosmosdb-throughput/scale-cosmosdb-throughput.sh
@@ -20,7 +20,8 @@ az group create \
 az cosmosdb create \
 	--name $accountName \
 	--kind GlobalDocumentDB \
-	--locations "South Central US"=0 "North Central US"=1 \
+	--locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
 	--resource-group $resourceGroupName \
 	--default-consistency-level "Session" \
     --enable-multiple-write-locations true

--- a/cosmosdb/secure-cosmosdb-create-firewall/secure-cosmosdb-create-firewall.sh
+++ b/cosmosdb/secure-cosmosdb-create-firewall/secure-cosmosdb-create-firewall.sh
@@ -18,7 +18,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --kind GlobalDocumentDB \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "Session"
 
 

--- a/cosmosdb/secure-cosmosdb-get-connection-string/secure-cosmosdb-get-connection-string
+++ b/cosmosdb/secure-cosmosdb-get-connection-string/secure-cosmosdb-get-connection-string
@@ -17,7 +17,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --kind GlobalDocumentDB \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "Session" \
     --enable-multiple-write-locations true
 

--- a/cosmosdb/secure-cosmosdb-get-mongodb-connection-string/secure-cosmosdb-get-mongodb-connection-string.sh
+++ b/cosmosdb/secure-cosmosdb-get-mongodb-connection-string/secure-cosmosdb-get-mongodb-connection-string.sh
@@ -17,7 +17,8 @@ az cosmosdb create \
     --resource-group $resourceGroupName \
     --name $accountName \
     --kind MongoDB \
-    --locations "South Central US"=0 "North Central US"=1 \
+    --locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
     --default-consistency-level "Session" \
     --enable-multiple-write-locations true
 

--- a/cosmosdb/secure-cosmosdb-regenerate-keys/secure-cosmosdb-regenerate-keys.sh
+++ b/cosmosdb/secure-cosmosdb-regenerate-keys/secure-cosmosdb-regenerate-keys.sh
@@ -17,7 +17,7 @@ az cosmosdb create \
 	--name $accountName \
 	--kind GlobalDocumentDB \
 	--locations regionName="South Central US" failoverPriority=0 \
-    --locations regionName="North Central US" failoverPriority=1 \
+	--locations regionName="North Central US" failoverPriority=1 \
 	--resource-group $resourceGroupName \
     --default-consistency-level "Session" \
     --enable-multiple-write-locations true

--- a/cosmosdb/secure-cosmosdb-regenerate-keys/secure-cosmosdb-regenerate-keys.sh
+++ b/cosmosdb/secure-cosmosdb-regenerate-keys/secure-cosmosdb-regenerate-keys.sh
@@ -16,7 +16,8 @@ az group create \
 az cosmosdb create \
 	--name $accountName \
 	--kind GlobalDocumentDB \
-	--locations "South Central US"=0 "North Central US"=1 \
+	--locations regionName="South Central US" failoverPriority=0 \
+    --locations regionName="North Central US" failoverPriority=1 \
 	--resource-group $resourceGroupName \
     --default-consistency-level "Session" \
     --enable-multiple-write-locations true


### PR DESCRIPTION
## Description

Updating Cosmos DB examples to contain new format for specifying account regions via the CLI. @SnehaGunda 

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [ ] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version: 2.0.67
```
az --version
```

Extensions required:
