### PR TITLE
update scale notes

### DIFF
--- a/mariadb/scale-mariadb-server/delete-mariadb.sh
+++ b/mariadb/scale-mariadb-server/delete-mariadb.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+RESOURCE_GROUP = "" # enter your resource group name
 az group delete --name $RESOURCE_GROUP

--- a/mariadb/scale-mariadb-server/delete-mariadb.sh
+++ b/mariadb/scale-mariadb-server/delete-mariadb.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-az group delete --name myresourcegroup
+az group delete --name $RESOURCE_GROUP

--- a/mariadb/scale-mariadb-server/scale-mariadb-server.sh
+++ b/mariadb/scale-mariadb-server/scale-mariadb-server.sh
@@ -28,13 +28,20 @@ az monitor metrics list \
 --metric storage_used \
 --interval PT1M
 
-# Scale up the server to provision more vCores within the same Tier
+# Scale up the server by provisionining more vCores within the same tier
 az mariadb server update \
 --resource-group myresourcegroup \
 --name mydemoserver \
 --sku-name GP_Gen5_4
 
+# Scale down the server by provisionining fewer vCores within the same tier
+az mariadb server update \
+--resource-group myresourcegroup \
+--name mydemoserver \
+--sku-name GP_Gen5_2
+
 # Scale up the server to provision a storage size of 7GB
+# Storage size cannot be reduced
 az mariadb server update \
 --resource-group myresourcegroup \
 --name mydemoserver \

--- a/mariadb/scale-mariadb-server/scale-mariadb-server.sh
+++ b/mariadb/scale-mariadb-server/scale-mariadb-server.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Set up variables
-RESOURCE_GROUP="myresourcegroup" ;
+RESOURCE_GROUP="myresourcegroup"
 SERVER_NAME="mydemoserver-$RANDOM"
-PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12)
+echo password $PASSWORD # returns the generated password
 LOCATION="westus"
 ADMIN_USER="myadmin"
 SUBSCRIPTION_ID="" # enter your subscription ID

--- a/mariadb/scale-mariadb-server/scale-mariadb-server.sh
+++ b/mariadb/scale-mariadb-server/scale-mariadb-server.sh
@@ -4,19 +4,21 @@
 RESOURCE_GROUP="myresourcegroup" ;
 SERVER_NAME="mydemoserver-$RANDOM"
 PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+LOCATION="westus"
+ADMIN_USER="myadmin"
 SUBSCRIPTION_ID="" # enter your subscription ID
 
 # Create a resource group
 az group create \
     --name $RESOURCE_GROUP \
-    --location westus
+    --location $LOCATION
 
 # Create a MariaDB server in the resource group
 az mariadb server create \
     --name $SERVER_NAME \
     --resource-group $RESOURCE_GROUP \
-    --location westus \
-    --admin-user myadmin \
+    --location $LOCATION \
+    --admin-user $ADMIN_USER \
     --admin-password $PASSWORD \
     --sku-name GP_Gen5_2
 

--- a/mysql/scale-mysql-server/delete-mysql.sh
+++ b/mysql/scale-mysql-server/delete-mysql.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+RESOURCE_GROUP = "" # enter your resource group name
 az group delete --name $RESOURCE_GROUP

--- a/mysql/scale-mysql-server/delete-mysql.sh
+++ b/mysql/scale-mysql-server/delete-mysql.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-az group delete --name myresourcegroup
+az group delete --name $RESOURCE_GROUP

--- a/mysql/scale-mysql-server/scale-mysql-server.sh
+++ b/mysql/scale-mysql-server/scale-mysql-server.sh
@@ -14,7 +14,7 @@ az mysql server create \
 --location westus \
 --admin-user myadmin \
 --admin-password <server_admin_password> \
---sku-name GP_Gen4_2 \
+--sku-name GP_Gen5_2 \
 
 # Monitor usage metrics - CPU
 az monitor metrics list \
@@ -28,13 +28,20 @@ az monitor metrics list \
 --metric storage_used \
 --interval PT1M
 
-# Scale up the server to provision more vCores within the same Tier
+# Scale up the server by provisionining more vCores within the same tier
 az mysql server update \
 --resource-group myresourcegroup \
 --name mydemoserver \
---sku-name GP_Gen4_4
+--sku-name GP_Gen5_4
+
+# Scale down the server by provisionining fewer vCores within the same tier
+az mysql server update \
+--resource-group myresourcegroup \
+--name mydemoserver \
+--sku-name GP_Gen5_2
 
 # Scale up the server to provision a storage size of 7GB
+# Storage size cannot be reduced
 az mysql server update \
 --resource-group myresourcegroup \
 --name mydemoserver \

--- a/mysql/scale-mysql-server/scale-mysql-server.sh
+++ b/mysql/scale-mysql-server/scale-mysql-server.sh
@@ -1,48 +1,52 @@
 #!/bin/bash
 
+# Set up variables
+RESOURCE_GROUP="myresourcegroup" ;
+SERVER_NAME="mydemoserver-$RANDOM"
+PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+SUBSCRIPTION_ID="" # enter your subscription ID
+
 # Create a resource group
 az group create \
---name myresourcegroup \
---location westus
+    --name $RESOURCE_GROUP \
+    --location westus
 
 # Create a MySQL server in the resource group
-# Name of a server maps to DNS name and is thus required to be globally unique in Azure.
-# Substitute the <server_admin_password> with your own value.
 az mysql server create \
---name mydemoserver \
---resource-group myresourcegroup \
---location westus \
---admin-user myadmin \
---admin-password <server_admin_password> \
---sku-name GP_Gen5_2 \
+    --name $SERVER_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --location westus \
+    --admin-user myadmin \
+    --admin-password $PASSWORD \
+    --sku-name GP_Gen5_2
 
 # Monitor usage metrics - CPU
 az monitor metrics list \
---resource "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.DBforMySQL/servers/mydemoserver" \
---metric cpu_percent \
---interval PT1M
+    --resource "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DBforMySQL/servers/$SERVER_NAME" \
+    --metric cpu_percent \
+    --interval PT1M
 
 # Monitor usage metrics - Storage
 az monitor metrics list \
---resource-id "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.DBforMySQL/servers/mydemoserver" \
---metric storage_used \
---interval PT1M
+    --resource "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DBforMySQL/servers/$SERVER_NAME" \
+    --metric storage_used \
+    --interval PT1M
 
 # Scale up the server by provisionining more vCores within the same tier
 az mysql server update \
---resource-group myresourcegroup \
---name mydemoserver \
---sku-name GP_Gen5_4
+    --resource-group $RESOURCE_GROUP \
+    --name $SERVER_NAME \
+    --sku-name GP_Gen5_4
 
-# Scale down the server by provisionining fewer vCores within the same tier
+# Scale down the server by provisioning fewer vCores within the same tier
 az mysql server update \
---resource-group myresourcegroup \
---name mydemoserver \
---sku-name GP_Gen5_2
+    --resource-group $RESOURCE_GROUP \
+    --name $SERVER_NAME \
+    --sku-name GP_Gen5_2
 
 # Scale up the server to provision a storage size of 7GB
 # Storage size cannot be reduced
 az mysql server update \
---resource-group myresourcegroup \
---name mydemoserver \
---storage-size 7168
+    --resource-group $RESOURCE_GROUP \
+    --name $SERVER_NAME \
+    --storage-size 7168

--- a/mysql/scale-mysql-server/scale-mysql-server.sh
+++ b/mysql/scale-mysql-server/scale-mysql-server.sh
@@ -4,19 +4,21 @@
 RESOURCE_GROUP="myresourcegroup" ;
 SERVER_NAME="mydemoserver-$RANDOM"
 PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+LOCATION="westus"
+ADMIN_USER="myadmin"
 SUBSCRIPTION_ID="" # enter your subscription ID
 
 # Create a resource group
 az group create \
     --name $RESOURCE_GROUP \
-    --location westus
+    --location $LOCATION
 
 # Create a MySQL server in the resource group
 az mysql server create \
     --name $SERVER_NAME \
     --resource-group $RESOURCE_GROUP \
-    --location westus \
-    --admin-user myadmin \
+    --location $LOCATION \
+    --admin-user $ADMIN_USER \
     --admin-password $PASSWORD \
     --sku-name GP_Gen5_2
 

--- a/mysql/scale-mysql-server/scale-mysql-server.sh
+++ b/mysql/scale-mysql-server/scale-mysql-server.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Set up variables
-RESOURCE_GROUP="myresourcegroup" ;
+RESOURCE_GROUP="myresourcegroup"
 SERVER_NAME="mydemoserver-$RANDOM"
-PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) 
+echo password $PASSWORD # returns the generated password
 LOCATION="westus"
 ADMIN_USER="myadmin"
 SUBSCRIPTION_ID="" # enter your subscription ID

--- a/postgresql/scale-postgresql-server/delete-postgresql.sh
+++ b/postgresql/scale-postgresql-server/delete-postgresql.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+RESOURCE_GROUP = "" # enter your resource group name
 az group delete --name $RESOURCE_GROUP

--- a/postgresql/scale-postgresql-server/delete-postgresql.sh
+++ b/postgresql/scale-postgresql-server/delete-postgresql.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-az group delete --name myresourcegroup
+az group delete --name $RESOURCE_GROUP

--- a/postgresql/scale-postgresql-server/scale-postgresql-server.sh
+++ b/postgresql/scale-postgresql-server/scale-postgresql-server.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Set up variables
-RESOURCE_GROUP="myresourcegroup" ;
+RESOURCE_GROUP="myresourcegroup"
 SERVER_NAME="mydemoserver-$RANDOM"
-PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12)
+echo password $PASSWORD # returns the generated password
 LOCATION="westus"
 ADMIN_USER="myadmin"
 SUBSCRIPTION_ID="" # enter your subscription ID

--- a/postgresql/scale-postgresql-server/scale-postgresql-server.sh
+++ b/postgresql/scale-postgresql-server/scale-postgresql-server.sh
@@ -1,48 +1,52 @@
 #!/bin/bash
 
+# Set up variables
+RESOURCE_GROUP="myresourcegroup" ;
+SERVER_NAME="mydemoserver-$RANDOM"
+PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+SUBSCRIPTION_ID="" # enter your subscription ID
+
 # Create a resource group
 az group create \
---name myresourcegroup \
---location westus
+    --name $RESOURCE_GROUP \
+    --location westus
 
 # Create a PostgreSQL server in the resource group
-# Name of a server maps to DNS name and is thus required to be globally unique in Azure.
-# Substitute the <server_admin_password> with your own value.
 az postgres server create \
---name mydemoserver \
---resource-group myresourcegroup \
---location westus \
---admin-user myadmin \
---admin-password <server_admin_password> \
---sku-name GP_Gen5_2 \
+    --name $SERVER_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --location westus \
+    --admin-user myadmin \
+    --admin-password $PASSWORD \
+    --sku-name GP_Gen5_2
 
 # Monitor usage metrics - CPU
 az monitor metrics list \
---resource "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.DBforPostgreSQL/servers/mydemoserver" \
---metric cpu_percent \
---interval PT1M
+    --resource "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DBforPostgreSQL/servers/$SERVER_NAME" \
+    --metric cpu_percent \
+    --interval PT1M
 
 # Monitor usage metrics - Storage
 az monitor metrics list \
---resource "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.DBforPostgreSQL/servers/mydemoserver" \
---metric storage_used \
---interval PT1M
+    --resource "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DBforPostgreSQL/servers/$SERVER_NAME" \
+    --metric storage_used \
+    --interval PT1M
 
 # Scale up the server by provisionining more vCores within the same tier
 az postgres server update \
---resource-group myresourcegroup \
---name mydemoserver \
---sku-name GP_Gen5_4
+    --resource-group $RESOURCE_GROUP \
+    --name $SERVER_NAME \
+    --sku-name GP_Gen5_4
 
 # Scale down the server by provisioning fewer vCores within the same tier
 az postgres server update \
---resource-group myresourcegroup \
---name mydemoserver \
---sku-name GP_Gen5_2
+    --resource-group $RESOURCE_GROUP \
+    --name $SERVER_NAME \
+    --sku-name GP_Gen5_2
 
 # Scale up the server to provision a storage size of 7GB
 # Storage size cannot be reduced
 az postgres server update \
---resource-group myresourcegroup \
---name mydemoserver \
---storage-size 7168
+    --resource-group $RESOURCE_GROUP \
+    --name $SERVER_NAME \
+    --storage-size 7168

--- a/postgresql/scale-postgresql-server/scale-postgresql-server.sh
+++ b/postgresql/scale-postgresql-server/scale-postgresql-server.sh
@@ -4,19 +4,21 @@
 RESOURCE_GROUP="myresourcegroup" ;
 SERVER_NAME="mydemoserver-$RANDOM"
 PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12) ; echo password $PASSWORD
+LOCATION="westus"
+ADMIN_USER="myadmin"
 SUBSCRIPTION_ID="" # enter your subscription ID
 
 # Create a resource group
 az group create \
     --name $RESOURCE_GROUP \
-    --location westus
+    --location $LOCATION
 
 # Create a PostgreSQL server in the resource group
 az postgres server create \
     --name $SERVER_NAME \
     --resource-group $RESOURCE_GROUP \
-    --location westus \
-    --admin-user myadmin \
+    --location $LOCATION \
+    --admin-user $ADMIN_USER \
     --admin-password $PASSWORD \
     --sku-name GP_Gen5_2
 

--- a/postgresql/scale-postgresql-server/scale-postgresql-server.sh
+++ b/postgresql/scale-postgresql-server/scale-postgresql-server.sh
@@ -14,7 +14,7 @@ az postgres server create \
 --location westus \
 --admin-user myadmin \
 --admin-password <server_admin_password> \
---sku-name GP_Gen4_2 \
+--sku-name GP_Gen5_2 \
 
 # Monitor usage metrics - CPU
 az monitor metrics list \
@@ -28,13 +28,20 @@ az monitor metrics list \
 --metric storage_used \
 --interval PT1M
 
-# Scale up the server to provision more vCores within the same Tier
+# Scale up the server by provisionining more vCores within the same tier
 az postgres server update \
 --resource-group myresourcegroup \
 --name mydemoserver \
---sku-name GP_Gen4_4
+--sku-name GP_Gen5_4
+
+# Scale down the server by provisioning fewer vCores within the same tier
+az postgres server update \
+--resource-group myresourcegroup \
+--name mydemoserver \
+--sku-name GP_Gen5_2
 
 # Scale up the server to provision a storage size of 7GB
+# Storage size cannot be reduced
 az postgres server update \
 --resource-group myresourcegroup \
 --name mydemoserver \


### PR DESCRIPTION
## Description

Updating the Postgres, MySQL, MariaDB examples to use Gen5, show that vCores can be scaled down, and emphasizes that storage can't be scaled down.

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [X] Scripts in this pull request are written for the `bash` shell.
- [x] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [ ] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version: 2.0.70
```
az --version
```

Extensions required: n/a
