### PR TITLE
Update 'blobsource' with 'httpUrl'

### DIFF
--- a/batch/render-scene/json/myrendertask_multi.json
+++ b/batch/render-scene/json/myrendertask_multi.json
@@ -3,7 +3,7 @@
     "commandLine": "cmd /c \"%3DSMAX_2018%3dsmaxcmdio.exe -secure off -v:5 -rfw:0 -start:2 -end:2 -outputName:\"dragon.jpg\" -w 400 -h 300 MotionBlur-DragonFlying.max\"",
     "resourceFiles": [
       {
-          "blobSource": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
+          "httpUrl": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
           "filePath": "MotionBlur-DragonFlying.max"
       }
   ],
@@ -32,7 +32,7 @@
     "commandLine": "cmd /c \"%3DSMAX_2018%3dsmaxcmdio.exe -secure off -v:5 -rfw:0 -start:3 -end:3 -outputName:\"dragon.jpg\" -w 400 -h 300 MotionBlur-DragonFlying.max\"",
     "resourceFiles": [
       {
-          "blobSource": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
+          "httpUrl": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
           "filePath": "MotionBlur-DragonFlying.max"
       }
   ],
@@ -61,7 +61,7 @@
     "commandLine": "cmd /c \"%3DSMAX_2018%3dsmaxcmdio.exe -secure off -v:5 -rfw:0 -start:4 -end:4 -outputName:\"dragon.jpg\" -w 400 -h 300 MotionBlur-DragonFlying.max\"",
     "resourceFiles": [
       {
-          "blobSource": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
+          "httpUrl": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
           "filePath": "MotionBlur-DragonFlying.max"
       }
   ],
@@ -90,7 +90,7 @@
     "commandLine": "cmd /c \"%3DSMAX_2018%3dsmaxcmdio.exe -secure off -v:5 -rfw:0 -start:5 -end:5 -outputName:\"dragon.jpg\" -w 400 -h 300 MotionBlur-DragonFlying.max\"",
     "resourceFiles": [
       {
-          "blobSource": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
+          "httpUrl": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
           "filePath": "MotionBlur-DragonFlying.max"
       }
   ],
@@ -119,7 +119,7 @@
     "commandLine": "cmd /c \"%3DSMAX_2018%3dsmaxcmdio.exe -secure off -v:5 -rfw:0 -start:6 -end:6 -outputName:\"dragon.jpg\" -w 400 -h 300 MotionBlur-DragonFlying.max\"",
     "resourceFiles": [
       {
-          "blobSource": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
+          "httpUrl": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
           "filePath": "MotionBlur-DragonFlying.max"
       }
   ],
@@ -148,7 +148,7 @@
     "commandLine": "cmd /c \"%3DSMAX_2018%3dsmaxcmdio.exe -secure off -v:5 -rfw:0 -start:7 -end:7 -outputName:\"dragon.jpg\" -w 400 -h 300 MotionBlur-DragonFlying.max\"",
     "resourceFiles": [
       {
-          "blobSource": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
+          "httpUrl": "https://mystorageaccount.blob.core.windows.net/scenefiles/MotionBlur-DragonFlying.max",
           "filePath": "MotionBlur-DragonFlying.max"
       }
   ],


### PR DESCRIPTION
Fixes issues with chance in schema since creation.

<!--
    Thanks for contributing to the Azure CLI samples repo! For contributors, make sure that you
    fill in the PR checklist in this template, and:

    * Internal contributors: Follow the style guides and PR submission process docs:
        - CLI style guide: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-cli?branch=master
        - Best practices: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-scripts?branch=master
        - PR submission process: https://review.docs.microsoft.com/en-us/help/contribute/contribute-scripts-pr-process?branch=master

    * External contributors: Make sure that you test _all_ of your scripts that you modified. You can't read the contribution
        guides yet, but reviewer feedback will be detailed and clear about any required changes.
-->

## Description

<!-- Include a brief description of your changes. -->

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [ ] Scripts in this pull request are written for the `bash` shell.
- [ ] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [x] Azure Cloud Shell
  - [ ] macOS
  - [ ] Windows Subsystem for Linux
- [ ] Scripts do not contain passwords or other secret tokens.
- [ ] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [ ] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version:
```
az --version
```

Extensions required:
