### PR TITLE
Fix service endpoint command, new keys commands

### DIFF
--- a/cosmosdb/common/keys.sh
+++ b/cosmosdb/common/keys.sh
@@ -29,20 +29,22 @@ az cosmosdb keys list \
 
 read -p "Press any key to list read only account keys"
 # List read-only keys
-az cosmosdb list-read-only-keys \
+az cosmosdb keys list \
     -n $accountName \
-    -g $resourceGroupName
+    -g $resourceGroupName \
+    --type read-only-keys
 
 read -p "Press any key to list connection strings"
 # List connection strings
-az cosmosdb list-connection-strings \
+az cosmosdb keys list \
     -n $accountName \
-    -g $resourceGroupName
+    -g $resourceGroupName \
+    --type connection-strings
 
 read -p "Press any key to regenerate secondary account keys"
 # Regenerate secondary account keys
 # key-kind values: primary, primaryReadonly, secondary, secondaryReadonly
-az cosmosdb regenerate-key \
+az cosmosdb keys regenerate \
     -n $accountName \
     -g $resourceGroupName \
     --key-kind secondary

--- a/cosmosdb/common/service-endpoints-ignore-missing-vnet.sh
+++ b/cosmosdb/common/service-endpoints-ignore-missing-vnet.sh
@@ -45,7 +45,7 @@ svcEndpoint=$(az network vnet subnet show -g $resourceGroupName -n $backEnd --vn
 az cosmosdb create -n $accountName -g $resourceGroupName
 
 # Add the virtual network rule but ignore the missing service endpoint on the subnet
-az cosmosdb networ-rule add \
+az cosmosdb network-rule add \
     -n $accountName \
     -g $resourceGroupName \
     --virtual-network $vnetName \


### PR DESCRIPTION
## Description

Fixed incorrect cli command for service endpoints.
Update commands for az cosmosdb keys

## Checklist

- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [X] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version:
2.0.75

Extensions required:
None