### PR TITLE
add min throughput

### DIFF
--- a/cosmosdb/cassandra/throughput.sh
+++ b/cosmosdb/cassandra/throughput.sh
@@ -1,6 +1,6 @@
 !/bin/bash
 
-# Update throughput for Cassandra keyspace and table
+# Throughput operations for a Cassandra keyspace and table
 
 # Generate a unique 10 character alphanumeric string to ensure unique resource names
 uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
@@ -11,24 +11,15 @@ location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 keySpaceName='keyspace1'
 tableName='table1'
+originalThroughput=400
+updateThroughput=500
 
-# Create a resource group
+# Create a resource group, Cosmos account, keyspace and table
 az group create -n $resourceGroupName -l $location
+az cosmosdb create -n $accountName -g $resourceGroupName --capabilities EnableCassandra
+az cosmosdb cassandra keyspace create -a $accountName -g $resourceGroupName -n $keySpaceName --throughput $originalThroughput
 
-# Create a new Cosmos account for Cassandra API
-az cosmosdb create \
-    -n $accountName \
-    -g $resourceGroupName \
-    --capabilities EnableCassandra
-
-# Create a new Cassandra Keyspace with shared throughput
-az cosmosdb cassandra keyspace create \
-    -a $accountName \
-    -g $resourceGroupName \
-    -n $keySpaceName \
-    --throughput 400
-
-# Define the schema for the Table
+# Define the schema for the table and create the table
 schema=$(cat << EOF 
 {
     "columns": [
@@ -36,37 +27,89 @@ schema=$(cat << EOF
         {"name": "columnB","type": "text"}
     ],
     "partitionKeys": [{"name": "columnA"}]
-}
-EOF
-)
-# Persist schema to json file
+} 
+EOF )
 echo "$schema" > "schema-$uniqueId.json"
-
-# Create a Cassandra table with dedicated throughput
-az cosmosdb cassandra table create \
-    -a $accountName \
-    -g $resourceGroupName \
-    -k $keySpaceName \
-    -n $tableName \
-    --throughput 400 \
-    --schema @schema-$uniqueId.json
-
-# Delete schema file
+az cosmosdb cassandra table create -a $accountName -g $resourceGroupName -k $keySpaceName -n $tableName --throughput $originalThroughput --schema @schema-$uniqueId.json
 rm -f "schema-$uniqueId.json"
 
-read -p 'Press any key to increase Keyspace throughput to 500'
+# Throughput operations for Cassandra API keyspace
+#   Read the current throughput
+#   Read the minimum throughput
+#   Make sure the updated throughput is not less than the minimum
+#   Update the throughput
+
+read -p 'Press any key to get current provisioned Keyspace throughput'
+
+az cosmosdb cassandra keyspace throughput show \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $keySpaceName \
+    --query resource.throughput \
+    -o tsv
+
+read -p 'Press any key to get minimum allowable Keyspace throughput'
+
+minimumThroughput=$(az cosmosdb cassandra keyspace throughput show \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $keySpaceName \
+    --query resource.minimumThroughput \
+    -o tsv)
+
+echo $minimumThroughput
+
+# Make sure the updated throughput is not less than the minimum allowed throughput
+if [ $updateThroughput -lt $minimumThroughput ]; then
+    updateThroughput=$minimumThroughput
+fi
+
+read -p 'Press any key to update Keyspace throughput'
 
 az cosmosdb cassandra keyspace throughput update \
     -a $accountName \
     -g $resourceGroupName \
     -n $keySpaceName \
-    --throughput 500
+    --throughput $updateThroughput
 
-read -p 'Press any key to increase Table throughput to 500'
+# Throughput operations for Cassandra API table
+#   Read the current throughput
+#   Read the minimum throughput
+#   Make sure the updated throughput is not less than the minimum
+#   Update the throughput
+
+read -p 'Press any key to get current provisioned Table throughput'
+
+az cosmosdb cassandra table throughput show \
+    -a $accountName \
+    -g $resourceGroupName \
+    -k $keySpaceName \
+    -n $tableName \
+    --query resource.throughput \
+    -o tsv
+
+read -p 'Press any key to get minimum allowable Table throughput'
+
+minimumThroughput=$(az cosmosdb cassandra table throughput show \
+    -a $accountName \
+    -g $resourceGroupName \
+    -k $keySpaceName \
+    -n $tableName \
+    --query resource.minimumThroughput \
+    -o tsv)
+
+echo $minimumThroughput
+
+# Make sure the updated throughput is not less than the minimum allowed throughput
+if [ $updateThroughput -lt $minimumThroughput ]; then
+    updateThroughput=$minimumThroughput
+fi
+
+read -p 'Press any key to update Table throughput'
 
 az cosmosdb cassandra table throughput update \
     -a $accountName \
     -g $resourceGroupName \
     -k $keySpaceName \
     -n $tableName \
-    --throughput 500
+    --throughput $updateThroughput

--- a/cosmosdb/gremlin/throughput.sh
+++ b/cosmosdb/gremlin/throughput.sh
@@ -1,6 +1,6 @@
 !/bin/bash
 
-# Update the throughput for a Gremlin database and graph
+# Throughput operations for a SQL API database and container
 
 # Generate a unique 10 character alphanumeric string to ensure unique resource names
 uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
@@ -11,45 +11,91 @@ location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'
 graphName='graph1'
+originalThroughput=400
+updateThroughput=500
 
-# Create a resource group
+# Create a resource group, Cosmos account, database with throughput and graph with throughput
 az group create -n $resourceGroupName -l $location
+az cosmosdb create -n $accountName -g $resourceGroupName --capabilities EnableGremlin
+az cosmosdb gremlin database create -a $accountName -g $resourceGroupName -n $databaseName --throughput $originalThroughput
+az cosmosdb gremlin graph create -a $accountName -g $resourceGroupName -d $databaseName -n $graphName -p '/zipcode' --throughput $originalThroughput
 
-# Create a Cosmos account for Gremlin API
-az cosmosdb create \
-    -n $accountName \
+
+# Throughput operations for Gremlin API database
+#   Read the current throughput
+#   Read the minimum throughput
+#   Make sure the updated throughput is not less than the minimum
+#   Update the throughput
+
+read -p 'Press any key to read current provisioned throughput on database'
+
+az cosmosdb gremlin database throughput show \
     -g $resourceGroupName \
-    --capabilities EnableGremlin
-
-# Create a Gremlin database with shared throughput
-az cosmosdb gremlin database create \
     -a $accountName \
-    -g $resourceGroupName \
     -n $databaseName \
-    --throughput 400
+    --query resource.throughput \
+    -o tsv
 
-# Create a Gremlin graph with dedicated throughput
-az cosmosdb gremlin graph create \
-    -a $accountName \
+read -p 'Press any key to read minimum throughput on database'
+
+minimumThroughput=$(az cosmosdb gremlin database throughput show \
     -g $resourceGroupName \
-    -d $databaseName \
-    -n $graphName \
-    -p '/zipcode' \
-    --throughput 400
+    -a $accountName \
+    -n $databaseName \
+    --query resource.minimumThroughput \
+    -o tsv)
 
-read -p 'Press any key to increase Database throughput to 500'
+echo $minimumThroughput
+
+# Make sure the updated throughput is not less than the minimum allowed throughput
+if [ $updateThroughput -lt $minimumThroughput ]; then
+    updateThroughput=$minimumThroughput
+fi
+
+read -p 'Press any key to update database throughput'
 
 az cosmosdb gremlin database throughput update \
     -a $accountName \
     -g $resourceGroupName \
     -n $databaseName \
-    --throughput 500
+    --throughput $updateThroughput
 
-read -p 'Press any key to increase Graph throughput to 500'
+# Throughput operations for Gremlin API graph
+#   Read the current throughput
+#   Read the minimum throughput
+#   Make sure the updated throughput is not less than the minimum
+#   Update the throughput
 
-az cosmosdb gremlin graph throughput update \
-    -a $accountName \
+read -p 'Press any key to read current provisioned throughput on a graph'
+
+az cosmosdb gremlin graph throughput show \
     -g $resourceGroupName \
+    -a $accountName \
     -d $databaseName \
     -n $graphName \
-    --throughput 500
+    --query resource.throughput \
+    -o tsv
+
+read -p 'Press any key to read minimum throughput on graph'
+
+minimumThroughput=$(az cosmosdb gremlin graph throughput show \
+    -g $resourceGroupName \
+    -a $accountName \
+    -d $databaseName \
+    -n $graphName \
+    --query resource.minimumThroughput \
+    -o tsv)
+
+echo $minimumThroughput
+
+# Make sure the updated throughput is not less than the minimum allowed throughput
+if [ $updateThroughput -lt $minimumThroughput ]; then
+    updateThroughput=$minimumThroughput
+fi
+
+az cosmosdb gremlin graph throughput update \
+    -g $resourceGroupName \
+    -a $accountName \
+    -d $databaseName \
+    -n $graphName \
+    --throughput $updateThroughput

--- a/cosmosdb/sql/throughput.sh
+++ b/cosmosdb/sql/throughput.sh
@@ -1,54 +1,100 @@
 !/bin/bash
 
-# Update throughput for a SQL API database and container
+# Throughput operations for a SQL API database and container
 
 # Generate a unique 10 character alphanumeric string to ensure unique resource names
 uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for SQL API resources
 resourceGroupName="Group-$uniqueId"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'
 containerName='container1'
+originalThroughput=400
+updateThroughput=500
 
-# Create a resource group
+# Create a resource group, Cosmos account, database and container
 az group create -n $resourceGroupName -l $location
+az cosmosdb create -n $accountName -g $resourceGroupName
+az cosmosdb sql database create -a $accountName -g $resourceGroupName -n $databaseName --throughput $originalThroughput
+az cosmosdb sql container create -a $accountName -g $resourceGroupName -d $databaseName -n $containerName -p '/myPk' --throughput $originalThroughput
 
-# Create a Cosmos account for SQL API
-az cosmosdb create \
-    -n $accountName \
-    -g $resourceGroupName
 
-# Create a SQL API database with shared throughput
-az cosmosdb sql database create \
-    -a $accountName \
+# Throughput operations for SQL API database
+#   Read the current throughput
+#   Read the minimum throughput
+#   Make sure the updated throughput is not less than the minimum
+#   Update the throughput
+read -p 'Press any key to read current provisioned throughput on database'
+
+az cosmosdb sql database throughput show \
     -g $resourceGroupName \
+    -a $accountName \
     -n $databaseName \
-    --throughput 400
+    --query resource.throughput \
+    -o tsv
 
-# Create a SQL API container, default index policy, dedicated throughput
-az cosmosdb sql container create \
-    -a $accountName \
+read -p 'Press any key to read minimum throughput on database'
+
+minimumThroughput=$(az cosmosdb sql database throughput show \
     -g $resourceGroupName \
-    -d $databaseName \
-    -n $containerName \
-    -p '/id' \
-    --throughput 400
+    -a $accountName \
+    -n $databaseName \
+    --query resource.minimumThroughput \
+    -o tsv)
 
-read -p 'Press any key to increase Database throughput to 500'
+echo $minimumThroughput
+
+# Make sure the updated throughput is not less than the minimum allowed throughput
+if [ $updateThroughput -lt $minimumThroughput ]; then
+    updateThroughput=$minimumThroughput
+fi
+
+read -p 'Press any key to update database throughput'
 
 az cosmosdb sql database throughput update \
     -a $accountName \
     -g $resourceGroupName \
     -n $databaseName \
-    --throughput 400
+    --throughput $updateThroughput
 
-read -p 'Press any key to increase Container throughput to 500'
+# Throughput operations for SQL API container
+# Read the current throughput
+# Read the minimum throughput
+# Make sure the updated throughput is not less than the minimum
+# Update the throughput
+read -p 'Press any key to read current provisioned throughput on container'
+
+az cosmosdb sql container throughput show \
+    -g $resourceGroupName \
+    -a $accountName \
+    -d $databaseName \
+    -n $containerName \
+    --query resource.throughput \
+    -o tsv
+
+read -p 'Press any key to read minimum throughput on container'
+
+minimumThroughput=$(az cosmosdb sql container throughput show \
+    -g $resourceGroupName \
+    -a $accountName \
+    -d $databaseName \
+    -n $containerName \
+    --query resource.minimumThroughput \
+    -o tsv)
+
+echo $minimumThroughput
+
+# Make sure the updated throughput is not less than the minimum allowed throughput
+if [ $updateThroughput -lt $minimumThroughput ]; then
+    updateThroughput=$minimumThroughput
+fi
+
+read -p 'Press any key to update container throughput'
 
 az cosmosdb sql container throughput update \
     -a $accountName \
     -g $resourceGroupName \
     -d $databaseName \
     -n $containerName \
-    --throughput 500
+    --throughput $updateThroughput

--- a/cosmosdb/table/throughput.sh
+++ b/cosmosdb/table/throughput.sh
@@ -1,6 +1,6 @@
 !/bin/bash
 
-# Update throughput for Table API table
+# Throughput operations for a Table API table
 
 # Generate a unique 10 character alphanumeric string to ensure unique resource names
 uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
@@ -10,27 +10,50 @@ resourceGroupName="Group-$uniqueId"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 tableName='table1'
+originalThroughput=400
+updateThroughput=500
 
-# Create a resource group
+# Create a resource group, Cosmos account and table
 az group create -n $resourceGroupName -l $location
+az cosmosdb create -n $accountName -g $resourceGroupName --capabilities EnableTable
+az cosmosdb table create -a $accountName -g $resourceGroupName -n $tableName --throughput $originalThroughput
 
-# Create a Cosmos account for Table API
-az cosmosdb create \
-    -n $accountName \
-    -g $resourceGroupName \
-    --capabilities EnableTable \
 
-# Create a Table API Table
-az cosmosdb table create \
+# Throughput operations for Table API table
+#   Read the current throughput
+#   Read the minimum throughput
+#   Make sure the updated throughput is not less than the minimum
+#   Update the throughput
+
+read -p 'Press any key to get current provisioned Table throughput'
+
+az cosmosdb table throughput show \
     -a $accountName \
     -g $resourceGroupName \
     -n $tableName \
-    --throughput 400
+    --query resource.throughput \
+    -o tsv
 
-read -p 'Press any key to increase Table throughput to 500'
+read -p 'Press any key to get minimum allowable Table throughput'
+
+minimumThroughput=$(az cosmosdb table throughput show \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $tableName \
+    --query resource.minimumThroughput \
+    -o tsv)
+
+echo $minimumThroughput
+
+# Make sure the updated throughput is not less than the minimum allowed throughput
+if [ $updateThroughput -lt $minimumThroughput ]; then
+    updateThroughput=$minimumThroughput
+fi
+
+read -p 'Press any key to update Table throughput'
 
 az cosmosdb table throughput update \
     -a $accountName \
     -g $resourceGroupName \
     -n $tableName \
-    --throughput 500
+    --throughput $updateThroughput


### PR DESCRIPTION
## Description

updates to throughput.sh scripts to include how to get minimumThroughput and use it on a resource.

## Checklist
- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [X] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version:
```
2.0.80
```

Extensions required:
None