### PR TITLE
add resource lock samples

### DIFF
--- a/cosmosdb/cassandra/lock.sh
+++ b/cosmosdb/cassandra/lock.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+resourceGroupName='mjbArmTest'
+accountName='mjb-cassandra'
+keyspaceName='keyspace1'
+tableName='table1'
+
+lockType='CanNotDelete' # CanNotDelete or ReadOnly
+keyspaceParent="databaseAccounts/$accountName"
+tableParent="databaseAccounts/$accountName/cassandraKeyspaces/$keyspaceName"
+keyspaceLockName="$keyspaceName-Lock"
+tableLockName="$tableName-Lock"
+
+
+# Create a delete lock on keyspace
+az lock create --name $keyspaceLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/cassandraKeyspaces \
+    --lock-type $lockType \
+    --parent $keyspaceParent \
+    --resource $keyspaceName
+
+# Create a delete lock on table
+az lock create --name $tableLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/tables \
+    --lock-type $lockType \
+    --parent $tableParent \
+    --resource $tableName
+
+# List all locks on a Cosmos account
+az lock list --resource-group $resourceGroupName \
+    --resource-name $accountName \
+    --namespace Microsoft.DocumentDB \
+    --resource-type databaseAccounts
+
+# Delete lock on keyspace
+lockid=$(az lock show --name $keyspaceLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/cassandraKeyspaces \
+        --resource $keyspaceName --parent $keyspaceParent \
+        --output tsv --query id)
+az lock delete --ids $lockid
+
+# Delete lock on table
+lockid=$(az lock show --name $tableLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/tables \
+        --resource-name $tableName \
+        --parent $tableParent \
+        --output tsv --query id)
+az lock delete --ids $lockid

--- a/cosmosdb/gremlin/lock.sh
+++ b/cosmosdb/gremlin/lock.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+resourceGroupName='mjbArmTest'
+accountName='mjb-gremlin'
+databaseName='database1'
+graphName='graph1'
+
+lockType='CanNotDelete' # CanNotDelete or ReadOnly
+databaseParent="databaseAccounts/$accountName"
+graphParent="databaseAccounts/$accountName/gremlinDatabases/$databaseName"
+databaseLockName="$databaseName-Lock"
+graphLockName="$containerName-Lock"
+
+
+# Create a delete lock on database
+az lock create --name $databaseLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/gremlinDatabases \
+    --lock-type $lockType \
+    --parent $databaseParent \
+    --resource $databaseName
+
+# Create a delete lock on graph
+az lock create --name $graphLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/graphs \
+    --lock-type $lockType \
+    --parent $graphParent \
+    --resource $graphName
+
+# List all locks on a Cosmos account
+az lock list --resource-group $resourceGroupName \
+    --resource-name $accountName \
+    --namespace Microsoft.DocumentDB \
+    --resource-type databaseAccounts
+
+# Delete lock on database
+lockid=$(az lock show --name $databaseLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/gremlinDatabases \
+        --resource $databaseName --parent $databaseParent \
+        --output tsv --query id)
+az lock delete --ids $lockid
+
+# Delete lock on graph
+lockid=$(az lock show --name $graphLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/graphs \
+        --resource-name $graphName --parent $graphParent \
+        --output tsv --query id)
+az lock delete --ids $lockid

--- a/cosmosdb/mongodb/lock.sh
+++ b/cosmosdb/mongodb/lock.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+resourceGroupName='myResourceGroup'
+accountName='my-cosmos-account'
+databaseName='myDatabase'
+collectionName='myCollection'
+
+lockType='CanNotDelete' # CanNotDelete or ReadOnly
+databaseParent="databaseAccounts/$accountName"
+collectionParent="databaseAccounts/$accountName/mongodbDatabases/$databaseName"
+databaseLockName="$databaseName-Lock"
+collectionLockName="$collectionName-Lock"
+
+
+# Create a delete lock on database
+az lock create --name $databaseLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/mongodbDatabases \
+    --lock-type $lockType \
+    --parent $databaseParent \
+    --resource $databaseName
+
+# Create a delete lock on collection
+az lock create --name $collectionLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/collections \
+    --lock-type $lockType \
+    --parent $collectionParent \
+    --resource $collectionName
+
+# List all locks on a Cosmos account
+az lock list --resource-group $resourceGroupName \
+    --resource-name $accountName \
+    --namespace Microsoft.DocumentDB \
+    --resource-type databaseAccounts
+
+# Delete lock on database
+lockid=$(az lock show --name $databaseLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/mongodbDatabases \
+        --resource $databaseName --parent $databaseParent \
+        --output tsv --query id)
+az lock delete --ids $lockid
+
+# Delete lock on collection
+lockid=$(az lock show --name $collectionLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/collections \
+        --resource-name $collectionName \
+        --parent $collectionParent \
+        --output tsv --query id)
+az lock delete --ids $lockid

--- a/cosmosdb/sql/lock.sh
+++ b/cosmosdb/sql/lock.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+resourceGroupName='myResourceGroup'
+accountName='my-cosmos-account'
+databaseName='myDatabase'
+containerName='myContainer'
+
+lockType='CanNotDelete' # CanNotDelete or ReadOnly
+databaseParent="databaseAccounts/$accountName"
+containerParent="databaseAccounts/$accountName/sqlDatabases/$databaseName"
+databaseLockName="$databaseName-Lock"
+containerLockName="$containerName-Lock"
+
+# Create a delete lock on database
+az lock create --name $databaseLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/sqlDatabases \
+    --lock-type $lockType \
+    --parent $databaseParent \
+    --resource $databaseName
+
+# Create a delete lock on container
+az lock create --name $containerLockName \
+    --resource-group $resourceGroupName \
+    --resource-type Microsoft.DocumentDB/containers \
+    --lock-type $lockType \
+    --parent $containerParent \
+    --resource $containerName
+
+# List all locks on a Cosmos account
+az lock list --resource-group $resourceGroupName \
+    --resource-name $accountName \
+    --namespace Microsoft.DocumentDB \
+    --resource-type databaseAccounts
+
+# Delete lock on database
+lockid=$(az lock show --name $databaseLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/sqlDatabases \
+        --resource $databaseName \
+        --parent $databaseParent \
+        --output tsv --query id)
+az lock delete --ids $lockid
+
+# Delete lock on container
+lockid=$(az lock show --name $containerLockName \
+        --resource-group $resourceGroupName \
+        --resource-type Microsoft.DocumentDB/containers \
+        --resource-name $containerName \
+        --parent $containerParent \
+        --output tsv --query id)
+az lock delete --ids $lockid

--- a/cosmosdb/table/lock.sh
+++ b/cosmosdb/table/lock.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+resourceGroupName='myResourceGroup'
+accountName='my-cosmos-account'
+tableName='myTable'
+
+lockType='CanNotDelete' # CanNotDelete or ReadOnly
+tableParent="databaseAccounts/$accountName"
+tableResourceType="$nameSpace/tables"
+tableLockName='$tableName-Lock'
+
+
+# Create a delete lock on table
+az lock create --name $tableLockName \
+    --resource-group $resourceGroupName \
+    --resource-type $tableResourceType \
+    --lock-type $lockType \
+    --parent $tableParent \
+    --resource $tableName
+
+# List all locks on a Cosmos account
+az lock list --resource-group $resourceGroupName \
+    --resource-name $accountName \
+    --namespace Microsoft.DocumentDB \
+    --resource-type databaseAccounts
+
+# Delete lock on table
+lockid=$(az lock show --name $tableLockName \
+        --resource-group $resourceGroupName \
+        --resource-type $tableResourceType \
+        --resource $tableName --parent $tableParent \
+        --output tsv --query id)
+az lock delete --ids $lockid


### PR DESCRIPTION
## Description

added bash scripts for resource locks

## Checklist

- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [X] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [ ] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version: 2.6.0
```
az --version
```

Extensions required:
