### PR TITLE
add autoscale and mongo server version

### DIFF
--- a/cosmosdb/cassandra/autoscale.sh
+++ b/cosmosdb/cassandra/autoscale.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Create a Cassandra keyspace and table with autoscale
+
+# Generate a unique 10 character alphanumeric string to ensure unique resource names
+uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+
+# Variables for Cassandra API resources
+resourceGroupName="Group-$uniqueId"
+location='westus2'
+accountName="cosmos-$uniqueId" #needs to be lower case
+keySpaceName='keyspace1'
+tableName='table1'
+maxThroughput=4000 #minimum = 4000
+
+# Create a resource group
+az group create -n $resourceGroupName -l $location
+
+# Create a Cosmos account for Cassandra API
+az cosmosdb create \
+    -n $accountName \
+    -g $resourceGroupName \
+    --capabilities EnableCassandra \
+    --default-consistency-level Eventual \
+    --locations regionName='West US 2' failoverPriority=0 isZoneRedundant=False 
+
+# Create a Cassandra Keyspace
+az cosmosdb cassandra keyspace create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $keySpaceName
+
+# Define the schema for the table
+schema=$(cat << EOF 
+{
+    "columns": [
+        {"name": "columna","type": "uuid"},
+        {"name": "columnb","type": "int"},
+        {"name": "columnc","type": "text"}
+    ],
+    "partitionKeys": [
+        {"name": "columna"}
+    ],
+    "clusterKeys": [
+        { "name": "columnb", "orderBy": "asc" }
+    ]
+}
+EOF
+)
+# Persist schema to json file
+echo "$schema" > "schema-$uniqueId.json"
+
+# Create the Cassandra table
+az cosmosdb cassandra table create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -k $keySpaceName \
+    -n $tableName \
+    --max-throughput $maxThroughput \
+    --schema @schema-$uniqueId.json
+
+# Clean up temporary schema file
+rm -f "schema-$uniqueId.json"

--- a/cosmosdb/gremlin/autoscale.sh
+++ b/cosmosdb/gremlin/autoscale.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Create a Gremlin API database and graph with autoscale
+
+# Generate a unique 10 character alphanumeric string to ensure unique resource names
+uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+
+# Variables for Gremlin API resources
+resourceGroupName="Group-$uniqueId"
+location='westus2'
+accountName="cosmos-$uniqueId" #needs to be lower case
+databaseName='database1'
+graphName='graph1'
+partitionKey='/myPartitionKey'
+maxThroughput=4000 #minimum = 4000
+
+# Create a resource group
+az group create -n $resourceGroupName -l $location
+
+# Create a Cosmos account for Gremlin API
+az cosmosdb create \
+    -n $accountName \
+    -g $resourceGroupName \
+    --capabilities EnableGremlin \
+    --default-consistency-level Eventual \
+    --locations regionName='West US 2' failoverPriority=0 isZoneRedundant=False
+
+# Create a Gremlin database
+az cosmosdb gremlin database create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $databaseName
+
+# Create a Gremlin graph with autoscale
+az cosmosdb gremlin graph create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -d $databaseName \
+    -n $graphName \
+    -p $partitionKey \
+    --max-throughput $maxThroughput

--- a/cosmosdb/mongodb/autoscale.sh
+++ b/cosmosdb/mongodb/autoscale.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Create a MongoDB API database with autoscale and 2 collections that share throughput
+
+# Generate a unique 10 character alphanumeric string to ensure unique resource names
+uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+
+# Variables for MongoDB API resources
+resourceGroupName="Group-$uniqueId"
+location='westus2'
+accountName="cosmos-$uniqueId" #needs to be lower case
+serverVersion='3.6' #3.2 or 3.6
+databaseName='database1'
+maxThroughput=4000 #minimum = 4000
+collection1Name='collection1'
+collection2Name='collection2'
+
+# Create a resource group
+az group create -n $resourceGroupName -l $location
+
+# Create a Cosmos account for MongoDB API
+az cosmosdb create \
+    -n $accountName \
+    -g $resourceGroupName \
+    --kind MongoDB \
+    --server-version $serverVersion \
+    --default-consistency-level Eventual \
+    --locations regionName='West US 2' failoverPriority=0 isZoneRedundant=False
+
+# Create a MongoDB API database with shared autoscale throughput
+az cosmosdb mongodb database create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $databaseName \
+    --max-throughput $maxThroughput
+
+# Create two MongoDB API collections to share throughput
+az cosmosdb mongodb collection create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -d $databaseName \
+    -n $collection1Name \
+    --shard 'myShardKey1'
+
+az cosmosdb mongodb collection create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -d $databaseName \
+    -n $collection2Name \
+    --shard 'myShardKey2'

--- a/cosmosdb/mongodb/create.sh
+++ b/cosmosdb/mongodb/create.sh
@@ -9,6 +9,7 @@ uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 
 resourceGroupName="Group-$uniqueId"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
+serverVersion='3.6' #3.2 or 3.6
 databaseName='database1'
 collectionName='collection1'
 
@@ -20,6 +21,7 @@ az cosmosdb create \
     -n $accountName \
     -g $resourceGroupName \
     --kind MongoDB \
+    --server-version $serverVersion \
     --default-consistency-level Eventual \
     --locations regionName='West US 2' failoverPriority=0 isZoneRedundant=False \
     --locations regionName='East US 2' failoverPriority=1 isZoneRedundant=False

--- a/cosmosdb/sql/autoscale.sh
+++ b/cosmosdb/sql/autoscale.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Create a SQL API database and container with autoscale
+
+# Generate a unique 10 character alphanumeric string to ensure unique resource names
+uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+# Variables for SQL API resources
+resourceGroupName="Group-$uniqueId"
+location='westus2'
+accountName="cosmos-$uniqueId" #needs to be lower case
+databaseName='database1'
+containerName='container1'
+partitionKey='/myPartitionKey'
+maxThroughput=4000 #minimum = 4000
+
+
+# Create a resource group
+az group create -n $resourceGroupName -l $location
+
+# Create a Cosmos account for SQL API
+az cosmosdb create \
+    -n $accountName \
+    -g $resourceGroupName \
+    --default-consistency-level Eventual \
+    --locations regionName='West US 2' failoverPriority=0 isZoneRedundant=False
+
+# Create a SQL API database
+az cosmosdb sql database create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $databaseName
+
+# Create a SQL API container with autoscale
+az cosmosdb sql container create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -d $databaseName \
+    -n $containerName \
+    -p $partitionKey \
+    --max-throughput $maxThroughput

--- a/cosmosdb/table/autoscale.sh
+++ b/cosmosdb/table/autoscale.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Create a Table API table with autoscale
+
+# Generate a unique 10 character alphanumeric string to ensure unique resource names
+uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+
+# Variables for Cassandra API resources
+resourceGroupName="Group-$uniqueId"
+location='westus2'
+accountName="cosmos-$uniqueId" #needs to be lower case
+tableName='table1'
+maxThroughput=4000 #minimum = 4000
+
+# Create a resource group
+az group create -n $resourceGroupName -l $location
+
+# Create a Cosmos account for Table API
+az cosmosdb create \
+    -n $accountName \
+    -g $resourceGroupName \
+    --capabilities EnableTable \
+    --default-consistency-level Eventual \
+    --locations regionName='West US 2' failoverPriority=0 isZoneRedundant=False
+
+# Create a Table API Table with autoscale
+az cosmosdb table create \
+    -a $accountName \
+    -g $resourceGroupName \
+    -n $tableName \
+    --max-throughput $maxThroughput


### PR DESCRIPTION
## Description

added autoscale throughput
added server version for MongoDB

## Checklist

- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [X] Linux
  - [ ] Azure Cloud Shell
  - [ ] macOS
  - [X] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version:
2.91

Extensions required:
N/A