### PR TITLE
1774088, updates to fix syntax highlighting issue.

### DIFF
--- a/cosmosdb/cassandra/autoscale.sh
+++ b/cosmosdb/cassandra/autoscale.sh
@@ -4,11 +4,8 @@
 #
 # Create a Cassandra keyspace and table with autoscale
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Cassandra API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 keySpaceName='keyspace1'

--- a/cosmosdb/cassandra/create.sh
+++ b/cosmosdb/cassandra/create.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Cassandra API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 keySpaceName='keyspace1'

--- a/cosmosdb/cassandra/throughput.sh
+++ b/cosmosdb/cassandra/throughput.sh
@@ -5,13 +5,9 @@
 # Throughput operations for a Cassandra keyspace and table
 #
 #
- 
-
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
 
 # Variables for Cassandra API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 keySpaceName='keyspace1'

--- a/cosmosdb/common/ipfirewall.sh
+++ b/cosmosdb/common/ipfirewall.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Resource group and Cosmos account variables
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 

--- a/cosmosdb/common/keys.sh
+++ b/cosmosdb/common/keys.sh
@@ -12,11 +12,8 @@
 #   List connection strings
 #   Regenerate account keys
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Resource group and Cosmos account variables
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 

--- a/cosmosdb/common/regions.sh
+++ b/cosmosdb/common/regions.sh
@@ -11,11 +11,8 @@
 
 # Note: Azure Comos accounts cannot include updates to regions with changes to other properties in the same operation
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Resource group and Cosmos account variables
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 

--- a/cosmosdb/common/service-endpoints-ignore-missing-vnet.sh
+++ b/cosmosdb/common/service-endpoints-ignore-missing-vnet.sh
@@ -11,11 +11,8 @@
 # the connected subnet is not yet configured for service endpoints.
 # This sample will then configure the subnet for service endpoints.
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Resource group and Cosmos account variables
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 

--- a/cosmosdb/common/service-endpoints.sh
+++ b/cosmosdb/common/service-endpoints.sh
@@ -7,11 +7,8 @@
 # Create an Azure Cosmos Account with a service endpoint connected to a backend subnet
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Resource group and Cosmos account variables
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 

--- a/cosmosdb/gremlin/autoscale.sh
+++ b/cosmosdb/gremlin/autoscale.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Gremlin API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'

--- a/cosmosdb/gremlin/create.sh
+++ b/cosmosdb/gremlin/create.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Gremlin API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'

--- a/cosmosdb/gremlin/throughput.sh
+++ b/cosmosdb/gremlin/throughput.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Gremlin API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'

--- a/cosmosdb/mongodb/autoscale.sh
+++ b/cosmosdb/mongodb/autoscale.sh
@@ -6,12 +6,8 @@
 #
 #
 
-
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for MongoDB API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 serverVersion='3.6' #3.2 or 3.6

--- a/cosmosdb/mongodb/create.sh
+++ b/cosmosdb/mongodb/create.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for MongoDB API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 serverVersion='3.6' #3.2 or 3.6

--- a/cosmosdb/mongodb/throughput.sh
+++ b/cosmosdb/mongodb/throughput.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for MongoDB API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'

--- a/cosmosdb/sql/autoscale.sh
+++ b/cosmosdb/sql/autoscale.sh
@@ -6,10 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
 # Variables for SQL API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'

--- a/cosmosdb/sql/create.sh
+++ b/cosmosdb/sql/create.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for SQL API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'

--- a/cosmosdb/sql/throughput.sh
+++ b/cosmosdb/sql/throughput.sh
@@ -6,10 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
 # Variables for SQL API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 databaseName='database1'

--- a/cosmosdb/table/autoscale.sh
+++ b/cosmosdb/table/autoscale.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Cassandra API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 tableName='table1'

--- a/cosmosdb/table/create.sh
+++ b/cosmosdb/table/create.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Cassandra API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 tableName='table1'

--- a/cosmosdb/table/throughput.sh
+++ b/cosmosdb/table/throughput.sh
@@ -6,11 +6,8 @@
 #
 #
 
-# Generate a unique 10 character alphanumeric string to ensure unique resource names
-$uniqueId=$(env LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 10 | head -n 1)
-
 # Variables for Cassandra API resources
-resourceGroupName="Group-$uniqueId"
+resourceGroupName="Group-$RANDOM"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
 tableName='table1'


### PR DESCRIPTION
## Description

Updates for azure-docs-pr/articles/cosmos-db/scripts/cli/* articles where the syntax highlighting in the **Sample script** section of each article was broken.

## Checklist

- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [ ] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version:
```
az --version
```

Extensions required:
