### PR TITLE
update index creation, add mongo wildcard indexes

### DIFF
--- a/cosmosdb/cassandra/create.sh
+++ b/cosmosdb/cassandra/create.sh
@@ -33,7 +33,7 @@ az cosmosdb cassandra keyspace create \
     -n $keySpaceName
 
 # Define the schema for the table
-schema=$(cat << EOF 
+printf ' 
 {
     "columns": [
         {"name": "columna","type": "uuid"},
@@ -46,11 +46,7 @@ schema=$(cat << EOF
     "clusterKeys": [
         { "name": "columnb", "orderBy": "asc" }
     ]
-}
-EOF
-)
-# Persist schema to json file
-echo "$schema" > "schema-$uniqueId.json"
+}' > "schema-$uniqueId.json"
 
 # Create the Cassandra table
 az cosmosdb cassandra table create \

--- a/cosmosdb/cassandra/throughput.sh
+++ b/cosmosdb/cassandra/throughput.sh
@@ -22,16 +22,14 @@ az cosmosdb create -n $accountName -g $resourceGroupName --capabilities EnableCa
 az cosmosdb cassandra keyspace create -a $accountName -g $resourceGroupName -n $keySpaceName --throughput $originalThroughput
 
 # Define the schema for the table and create the table
-schema=$(cat << EOF 
+printf ' 
 {
     "columns": [
         {"name": "columnA","type": "uuid"}, 
         {"name": "columnB","type": "text"}
     ],
     "partitionKeys": [{"name": "columnA"}]
-} 
-EOF )
-echo "$schema" > "schema-$uniqueId.json"
+}' > "schema-$uniqueId.json"
 az cosmosdb cassandra table create -a $accountName -g $resourceGroupName -k $keySpaceName -n $tableName --throughput $originalThroughput --schema @schema-$uniqueId.json
 rm -f "schema-$uniqueId.json"
 

--- a/cosmosdb/gremlin/create.sh
+++ b/cosmosdb/gremlin/create.sh
@@ -33,7 +33,7 @@ az cosmosdb gremlin database create \
     -n $databaseName
 
 # Define the index policy for the graph, include spatial and composite indexes
-idxpolicy=$(cat << EOF 
+printf ' 
 {
     "indexingMode": "consistent", 
     "includedPaths": [
@@ -51,11 +51,7 @@ idxpolicy=$(cat << EOF
             { "path":"/age", "order":"descending" }
         ]
     ]
-}
-EOF
-)
-# Persist index policy to json file
-echo "$idxpolicy" > "idxpolicy-$uniqueId.json"
+}' > "idxpolicy-$uniqueId.json"
 
 # Create a Gremlin graph
 az cosmosdb gremlin graph create \

--- a/cosmosdb/mongodb/autoscale.sh
+++ b/cosmosdb/mongodb/autoscale.sh
@@ -11,7 +11,7 @@ uniqueId=$RANDOM
 resourceGroupName="Group-$uniqueId"
 location='westus2'
 accountName="cosmos-$uniqueId" #needs to be lower case
-serverVersion='3.6' #3.2 or 3.6
+serverVersion='4.0' #3.2, 3.6, 4.0
 databaseName='database1'
 maxThroughput=4000 #minimum = 4000
 collection1Name='collection1'

--- a/cosmosdb/mongodb/throughput.sh
+++ b/cosmosdb/mongodb/throughput.sh
@@ -22,11 +22,7 @@ az cosmosdb create -n $accountName -g $resourceGroupName --kind MongoDB
 az cosmosdb mongodb database create -a $accountName -g $resourceGroupName -n $databaseName --throughput $originalThroughput
 
 # Define a minimal index policy for the collection
-idxpolicy=$(cat << EOF 
-    [ {"key": {"keys": ["user_id"]}} ]
-EOF
-)
-echo "$idxpolicy" > "idxpolicy-$uniqueId.json"
+printf '[ {"key": {"keys": ["_id"]}} ]' > idxpolicy-$uniqueId.json
 
 # Create a MongoDB API collection
 az cosmosdb mongodb collection create -a $accountName -g $resourceGroupName -d $databaseName -n $collectionName --shard 'user_id' --throughput $originalThroughput --idx @idxpolicy-$uniqueId.json

--- a/cosmosdb/sql/create.sh
+++ b/cosmosdb/sql/create.sh
@@ -32,7 +32,7 @@ az cosmosdb sql database create \
     -n $databaseName
 
 # Define the index policy for the container, include spatial and composite indexes
-idxpolicy=$(cat << EOF 
+printf ' 
 {
     "indexingMode": "consistent", 
     "includedPaths": [
@@ -50,11 +50,7 @@ idxpolicy=$(cat << EOF
             { "path":"/age", "order":"descending" }
         ]
     ]
-}
-EOF
-)
-# Persist index policy to json file
-echo "$idxpolicy" > "idxpolicy-$uniqueId.json"
+}' > "idxpolicy-$uniqueId.json"
 
 # Create a SQL API container
 az cosmosdb sql container create \


### PR DESCRIPTION
## Description

update how index files are created. Simplified and also fixed a bug for when a $ is in the index.
Added wildcard indexes and default _id index for mongo samples.

## Checklist

- [X] Scripts in this pull request are written for the `bash` shell.
- [ ] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [X] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version: 2.22.1

Extensions required: N/A
