### PR TITLE
Add qoutes around --query parameters

### DIFF
--- a/container-registry/service-principal-create/service-principal-create.sh
+++ b/container-registry/service-principal-create/service-principal-create.sh
@@ -8,7 +8,7 @@ ACR_NAME=<container-registry-name>
 SERVICE_PRINCIPAL_NAME=acr-service-principal
 
 # Obtain the full registry ID for subsequent command args
-ACR_REGISTRY_ID=$(az acr show --name $ACR_NAME --query id --output tsv)
+ACR_REGISTRY_ID=$(az acr show --name $ACR_NAME --query "id" --output tsv)
 
 # Create the service principal with rights scoped to the registry.
 # Default permissions are for docker pull access. Modify the '--role'
@@ -16,7 +16,7 @@ ACR_REGISTRY_ID=$(az acr show --name $ACR_NAME --query id --output tsv)
 # acrpull:     pull only
 # acrpush:     push and pull
 # owner:       push, pull, and assign roles
-SP_PASSWD=$(az ad sp create-for-rbac --name $SERVICE_PRINCIPAL_NAME --scopes $ACR_REGISTRY_ID --role acrpull --query password --output tsv)
+SP_PASSWD=$(az ad sp create-for-rbac --name $SERVICE_PRINCIPAL_NAME --scopes $ACR_REGISTRY_ID --role acrpull --query "password" --output tsv)
 SP_APP_ID=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query "[].appId" --output tsv)
 
 # Output the service principal's credentials; use these in your services and

--- a/container-registry/service-principal-create/service-principal-create.sh
+++ b/container-registry/service-principal-create/service-principal-create.sh
@@ -17,7 +17,7 @@ ACR_REGISTRY_ID=$(az acr show --name $ACR_NAME --query id --output tsv)
 # acrpush:     push and pull
 # owner:       push, pull, and assign roles
 SP_PASSWD=$(az ad sp create-for-rbac --name $SERVICE_PRINCIPAL_NAME --scopes $ACR_REGISTRY_ID --role acrpull --query password --output tsv)
-SP_APP_ID=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query [].appId --output tsv)
+SP_APP_ID=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query "[].appId" --output tsv)
 
 # Output the service principal's credentials; use these in your services and
 # applications to authenticate to the container registry.

--- a/container-registry/service-principal-create/service-principal-create.sh
+++ b/container-registry/service-principal-create/service-principal-create.sh
@@ -16,10 +16,10 @@ ACR_REGISTRY_ID=$(az acr show --name $ACR_NAME --query "id" --output tsv)
 # acrpull:     pull only
 # acrpush:     push and pull
 # owner:       push, pull, and assign roles
-SP_PASSWD=$(az ad sp create-for-rbac --name $SERVICE_PRINCIPAL_NAME --scopes $ACR_REGISTRY_ID --role acrpull --query "password" --output tsv)
-SP_APP_ID=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query "[].appId" --output tsv)
+PASSWORD=$(az ad sp create-for-rbac --name $SERVICE_PRINCIPAL_NAME --scopes $ACR_REGISTRY_ID --role acrpull --query "password" --output tsv)
+USER_NAME=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query "[].appId" --output tsv)
 
 # Output the service principal's credentials; use these in your services and
 # applications to authenticate to the container registry.
-echo "Service principal ID: $SP_APP_ID"
-echo "Service principal password: $SP_PASSWD"
+echo "Service principal ID: $USER_NAME"
+echo "Service principal password: $PASSWORD"


### PR DESCRIPTION
Signed-off-by: Steve Lasker <stevenlasker@hotmail.com>

## Description

The sample, contained in the Azure docs, uses this line:
```bash
SP_APP_ID=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query [].appId --output tsv)
```
However, it generates an error:
```bash
zsh: no matches found: [].appId
```

## Fix

- Add quotes to named parameters. 

## Checklist

- [x] Scripts in this pull request are written for the `bash` shell.
- [x] This pull request was tested on __at least one of__ the following platforms:
  - [x] Linux
  - [x] Azure Cloud Shell
  - [ ] macOS
  - [x] Windows Subsystem for Linux
- [x] Scripts do not contain passwords or other secret tokens.
- [x] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [x] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version:
```
az --version

azure-cli                         2.29.1 *

core                              2.29.1 *
telemetry                          1.0.6

Extensions:
aks-preview                        0.5.0

Python location '/opt/az/bin/python3'
Extensions directory '/home/stevelas/.azure/cliextensions'

Python (Linux) 3.6.10 (default, Oct 21 2021, 06:49:47)
[GCC 9.3.0]
```
and, cloudshell:
```bash
az version
Azure-cli    Azure-cli-core    Azure-cli-telemetry
-----------  ----------------  ---------------------
2.29.0       2.29.0            1.0.6
```
Extensions required:
none