### PR TITLE
Fix allowed values for the storage SKU

### DIFF
--- a/azure-functions/create-function-app-premium-plan/create-function-app-premium-plan.sh
+++ b/azure-functions/create-function-app-premium-plan/create-function-app-premium-plan.sh
@@ -12,8 +12,8 @@ tag="create-function-app-premium-plan"
 storage="msdocsaccount$randomIdentifier"
 premiumPlan="msdocs-premium-plan-$randomIdentifier"
 functionApp="msdocs-function-$randomIdentifier"
-skuStorage="Standard_LRS"
-skuPlan="EP1" # Allowed values: Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Premium_LRS, Premium_ZRS, Standard_GZRS, Standard_RAGZRS
+skuStorage="Standard_LRS" # Allowed values: Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Premium_LRS, Premium_ZRS, Standard_GZRS, Standard_RAGZRS
+skuPlan="EP1"
 functionsVersion="4"
 
 # Create a resource group


### PR DESCRIPTION


<!--
    Thanks for contributing to the Azure CLI samples repo! For contributors, make sure that you
    fill in the PR checklist in this template, and:

    * Internal contributors: Follow the style guides and PR submission process docs:
        - CLI style guide: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-cli?branch=master
        - Best practices: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-scripts?branch=master
        - PR submission process: https://review.docs.microsoft.com/en-us/help/contribute/contribute-scripts-pr-process?branch=master

    * External contributors: Make sure that you test _all_ of your scripts that you modified. You can't read the contribution
        guides yet, but reviewer feedback will be detailed and clear about any required changes.
-->

## Description

A comment with the list of allowed values for a storage account SKU was attached to the skuPlan instead of skuStorage variable.

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [ ] Windows Subsystem for Linux
- [X] Scripts do not contain passwords or other secret tokens.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

CLI version:
```
az --version
```

Extensions required:
