### PR TITLE
add free-tier script

### DIFF
--- a/cosmosdb/common/find-free-tier-account.sh
+++ b/cosmosdb/common/find-free-tier-account.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Passed validation in Cloud Shell on 7/7/2022
+
+# <FullScript>
+# Azure Cosmos DB offers one free-tier account per subscription
+# This script will find if you have a free-tier account and output 
+# the name of the Cosmos DB account and its resource group 
+
+
+# These can remain commented out if running in Azure Cloud Shell
+
+#az login
+#az account set -s {your subscription id}
+
+isFound=0
+
+# Iterate through all the resource groups in the subscription
+for rg in $(az group list --query "[].name" --output tsv) 
+do
+
+	echo "Checking resource group: $rg"
+	
+	# Return the Cosmos DB account in the resource group marked as free tier
+	ft=$(az cosmosdb list -g $rg --query "[?enableFreeTier].name" --output tsv)
+	
+	if [ ${#ft} -gt 0 ]; then
+		
+		echo "$ft is a free tier account in resource group: $rg"
+		isFound=1
+		break
+	
+	fi
+
+done
+
+if [ $isFound -eq 0 ]; then
+	echo "No Free Tier accounts in subscription"
+fi


### PR DESCRIPTION
## Description

This script is to allow users to find the free-tier Cosmos DB account within their subscription.

- [X] Scripts in this pull request are written for the `bash` shell.
- [X] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [X] Azure Cloud Shell
  - [ ] macOS
  - [X] Windows Subsystem for Linux
- [X] The most recent test date and test method are recorded in the script file.
- [X] Scripts do not contain passwords or other secret tokens that are not randomized.
- [X] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [ ] All Azure resource identifiers which must be universally unique are guaranteed to be so.
- [ ] Resource names use a random function to ensure scripts can be run multiple times in quick succession without error.
- [X] All scripts can be run in their entirely without user input.


