### PR TITLE
Creating Powershell Conversion for Creating Azure Resources at Scale.ps1

### DIFF
--- a/azure-cli/create-azure-resources-at-scale/powershell/create-azure-resources-at-scale.ps1
+++ b/azure-cli/create-azure-resources-at-scale/powershell/create-azure-resources-at-scale.ps1
@@ -1,7 +1,6 @@
 # Passed validation in Ubuntu 22.04.3 LTS on 4/29/2024
 
 # <VariableBlock>
-# Variable block
 $subscriptionID = "00000000-0000-0000-0000-00000000"
 $setupFileLocation = "myFilePath\myFileName.csv"
 $logFileLocation = "myFilePath\myLogName.txt"
@@ -17,144 +16,179 @@ $vmName = "msdocs-vm-"
 $vmImage = ""
 $publicIpSku = ""
 $adminUser = ""
-$adminPassword = "msdocs-pw-"
+$adminPassword = "msdocs-PW-@"
 
 $vnetName = "msdocs-vnet-"
 $subnetName = "msdocs-subnet-"
 $vnetAddressPrefix = ""
-$subnetAddressPrefix = ""
+$subnetAddressPrefixes = ""
 
-# Set Azure subscription
-Set-AzContext -SubscriptionId $subscriptionID
-# </VariableBlock>
+# Set azure subscription
+az account set --subscription $subscriptionID
 
-# <ValidateFileValues>
-#Skip the header line
-$csvData = Import-Csv -Path $setupFileLocation | Select-Object -Skip 1
-foreach ($row in $csvData) {
-    $randomIdentifier = [int]([math]::Abs([System.Random]::new().Next()))
-    $resourceNo = $row.resourceNo
-    $location = $row.location
-    $createRG = $row.createRG
-    $existingRgName = $row.existingRgName
-    $createVnet = $row.createVnet
-    $vmImage = $row.vmImage
-    $publicIpSku = $row.publicIpSku
-    $adminUser = $row.adminUser
-    $vnetAddressPrefix = $row.vnetAddressPrefix
-    $subnetAddressPrefix = $row.subnetAddressPrefix
+# </ValidateFileValues>
+# Validate file values
 
-    Write-Host "resourceNo = $resourceNo"
-    Write-Host "location = $location"
-    Write-Host ""
+# Skip header line
+$csvData = Import-Csv $setupFileLocation | Select-Object -Skip 1
 
-    Write-Host "RESOURCE GROUP INFORMATION:"
-    Write-Host "createRG = $createRG"
-    if ($createRG -eq "TRUE") {
-        Write-Host "newRGName = $newRgName$randomIdentifier"
+foreach ($line in $csvData) {
+    $resourceNo = $line.resourceNo
+    $location = $line.location
+    $createRG = $line.createRG
+    $existingRgName = $line.existingRgName
+    $createVnet = $line.createVnet
+    $vnetAddressPrefix = $line.vnetAddressPrefix
+    $subnetAddressPrefixes = $line.subnetAddressPrefixes
+    $vmImage = $line.vmImage
+    $publicIpSku = $line.publicIpSku
+    $adminUser = $line.adminUser
+
+    $randomIdentifier = Get-Random
+
+    if ($resourceNo -eq "1") {
+        Write-Output "resourceNo = $resourceNo"
+        Write-Output "location = $location"
+        Write-Output ""
+
+        Write-Output "RESOURCE GROUP INFORMATION:"
+        Write-Output "createRG = $createRG"
+        if ($createRG -eq "TRUE") {
+            Write-Output "newRGName = $($newRgName)$randomIdentifier"
+        } else {
+            Write-Output "existingRgName = $existingRgName"
+        }
+        Write-Output ""
+
+        Write-Output "VNET INFORMATION:"
+        Write-Output "createVnet = $createVnet"
+        if ($createVnet -eq "TRUE") {
+            Write-Output "vnetName = $($vnetName)$randomIdentifier"
+            Write-Output "subnetName = $($subnetName)$randomIdentifier"
+            Write-Output "vnetAddressPrefix = $vnetAddressPrefix"
+            Write-Output "subnetAddressPrefixes = $subnetAddressPrefixes"
+        }
+        Write-Output ""
+
+        Write-Output "VM INFORMATION:"
+        Write-Output "vmName = $($vmName)$randomIdentifier"
+        Write-Output "vmImage = $vmImage"
+        Write-Output "vmSku = $publicIpSku"
+        Write-Output "vmAdminUser = $adminUser"
+        Write-Output "vmAdminPassword = $($adminPassword)$randomIdentifier"
     }
-    else {
-        Write-Host "existingRgName = $existingRgName"
-    }
-    Write-Host ""
-
-    Write-Host "VNET INFORMATION:"
-    Write-Host "createVnet = $createVnet"
-    if ($createVnet -eq "TRUE") {
-        Write-Host "vnetName = $vnetName$randomIdentifier"
-        Write-Host "subnetName = $subnetName$randomIdentifier"
-        Write-Host "vnetAddressPrefix = $vnetAddressPrefix"
-        Write-Host "subnetAddressPrefix = $subnetAddressPrefix"
-    }
-    Write-Host ""
-
-    Write-Host "VM INFORMATION:"
-    Write-Host "vmName = $vmName$randomIdentifier"
-    Write-Host "vmImage = $vmImage"
-    Write-Host "vmSku = $publicIpSku"
-    Write-Host "vmAdminUser = $adminUser"
-    Write-Host "vmAdminPassword = $adminPassword$randomIdentifier"
 }
+
 # </ValidateFileValues>
 
 # <ValidateScriptLogic>
 # Validate script logic
-Write-Output "Validating script" | Out-File -FilePath $logFileLocation
+"Validating script" | Out-File $logFileLocation
 
-#Skip the header line
-$csvData = Import-Csv -Path $setupFileLocation | Select-Object -Skip 1
-foreach ($row in $csvData) {
-    $resourceNo = $row.resourceNo
-    $randomIdentifier = [int]([math]::Abs([System.Random]::new().Next()))
-    $createRG = $row.createRG
-    $createVnet = $row.createVnet
+# Skip header line
+$setupData = Get-Content $setupFileLocation | Select-Object -Skip 1
 
-    Write-Output "resourceNo = $resourceNo" | Out-File -FilePath $logFileLocation -Append
+foreach ($line in $setupData) {
+    # Parse CSV line
+    $resourceNo, $location, $createRG, $existingRgName, $createVnet, $vnetAddressPrefix, $subnetAddressPrefixes, $vmImage, $publicIpSku, $adminUser = $line -split ','
+
+    # Log resource number
+    "resourceNo = $resourceNo" | Out-File $logFileLocation -Append
+
+    # Generate random identifier
+    $randomIdentifier = Get-Random * Get-Random
+
+    "create RG flag = $createRG" | Out-File $logFileLocation -Append
+    "create Vnet flag = $createVnet" | Out-File $logFileLocation -Append
+
+    # Check if a new resource group should be created
     if ($createRG -eq "TRUE") {
-        Write-Output "creating RG $newRgName$randomIdentifier" | Out-File -FilePath $logFileLocation -Append
-        $existingRgName = "$newRgName$randomIdentifier"
-    }
-    if ($createVnet -eq "TRUE") {
-        Write-Output "creating VNet $vnetName$randomIdentifier in RG $existingRgName" | Out-File -FilePath $logFileLocation -Append
-        Write-Output "creating VM $vmName$randomIdentifier within Vnet $vnetName$randomIdentifier in RG $existingRgName" | Out-File -FilePath $logFileLocation -Append
-    }
-    else {
-        Write-Output "creating VM $vmName$randomIdentifier without Vnet in RG $existingRgName" | Out-File -FilePath $logFileLocation -Append
+        $newRgName = $existingRgName + $randomIdentifier
+        "will create RG $newRgName" | Out-File $logFileLocation -Append
+        $existingRgName = $newRgName
     }
 
-    # Read your log file
-    Clear-Host
-    Get-Content -Path $logFileLocation
+    # Check if a new VNet should be created
+    if ($createVnet -eq "TRUE") {
+        $vnetName = "VNet" + $randomIdentifier
+        "will create VNet $vnetName in RG $existingRgName" | Out-File $logFileLocation -Append
+        $vmName = "VM" + $randomIdentifier
+        "will create VM $vmName in Vnet $vnetName in RG $existingRgName" | Out-File $logFileLocation -Append
+    } else {
+        $vmName = "VM" + $randomIdentifier
+        "will create VM $vmName in RG $existingRgName" | Out-File $logFileLocation -Append
+    }
 }
+
+# Display log file
+Clear-Host
+Get-Content $logFileLocation  
 
 # </ValidateScriptLogic>
 
 # <FullScript>
-# create Azure resources
-$logFileLocation = "C:\path\to\log.txt"
-$setupFileLocation = "C:\path\to\setup.csv"
+# Create Azure resources
+"Creating Azure resources" > $logFileLocation
 
-#Skip the header line
-Get-Content $setupFileLocation | Select-Object -Skip 1 | ForEach-Object {
-    $resourceNo, $location, $createRG, $existingRgName, $createVnet, $vmImage, $publicIpSku, $adminUser, $vnetAddressPrefix, $subnetAddressPrefix = $_ -split ','
+# Skip header line
+$setupFileContent = Get-Content $setupFileLocation | Select-Object -Skip 1
 
-    Add-Content $logFileLocation "resourceNo = $resourceNo"
+foreach ($line in $setupFileContent) {
+    $resourceDetails = $line.Split(',')
+    $resourceNo = $resourceDetails[0]
+    $location = $resourceDetails[1]
+    $createRG = $resourceDetails[2]
+    $existingRgName = $resourceDetails[3]
+    $createVnet = $resourceDetails[4]
+    $vnetAddressPrefix = $resourceDetails[5]
+    $subnetAddressPrefixes = $resourceDetails[6]
+    $vmImage = $resourceDetails[7]
+    $publicIpSku = $resourceDetails[8]
+    $adminUser = $resourceDetails[9]
 
-    $randomIdentifier = (Get-Random) * (Get-Random)
+    "resourceNo = $resourceNo" >> $logFileLocation
+    $randomIdentifier = [System.Random]::new().Next(1, 1000000)
 
     if ($createRG -eq "TRUE") {
-        Add-Content $logFileLocation "creating RG $($newRgName)$randomIdentifier"
-        az group create --location $location --name $($newRgName)$randomIdentifier
-        $existingRgName = "$($newRgName)$randomIdentifier"
+        $newRgName = "myRgName"
+        $rgName = "$newRgName$randomIdentifier"
+        "creating RG $rgName" >> $logFileLocation
+        New-AzResourceGroup -Name $rgName -Location $location
+        $existingRgName = $rgName
+        "RG $rgName creation complete" >> $logFileLocation
     }
 
     if ($createVnet -eq "TRUE") {
-        Add-Content $logFileLocation "creating VNet $($vnetName)$randomIdentifier in RG $existingRgName"
-        az network vnet create `
-            --name "$($vnetName)$randomIdentifier" `
-            --resource-group $existingRgName `
-            --address-prefix $vnetAddressPrefix `
-            --subnet-name "$($subnetName)$randomIdentifier" `
-            --subnet-prefixes $subnetAddressPrefix
+        $vnetName = "myVnetName"
+        $subnetName = "mySubnetName"
+        $vmName = "myVmName"
+        "creating VNet $($vnetName)$randomIdentifier in RG $existingRgName with adrPX $vnetAddressPrefix, snName $($subnetName)$randomIdentifier and snPXs $subnetAddressPrefixes" >> $logFileLocation
+        $subnet = New-AzVirtualNetworkSubnetConfig -Name "$($subnetName)$randomIdentifier" -AddressPrefix $subnetAddressPrefixes
+        $vnet = New-AzVirtualNetwork -Name "$($vnetName)$randomIdentifier" -ResourceGroupName $existingRgName -Location $location -AddressPrefix $vnetAddressPrefix -Subnet $subnet
+        "VNet $($vnetName)$randomIdentifier creation complete" >> $logFileLocation
 
-        Add-Content $logFileLocation "creating VM $($vmName)$randomIdentifier within Vnet $($vnetName)$randomIdentifier in RG $existingRgName"
-        az vm create `
-            --resource-group $existingRgName `
-            --name "$($vmName)$randomIdentifier" `
-            --image $vmImage `
-            --vnet-name "$($vnetName)$randomIdentifier" `
-            --public-ip-sku $publicIpSku `
-            --admin-username $adminUser `
-            --admin-password "$($adminPassword)$randomIdentifier"
-    } else {
-        Add-Content $logFileLocation "creating VM $($vmName)$randomIdentifier without Vnet in RG $existingRgName"
-        az vm create `
-            --resource-group $existingRgName `
-            --name "$($vmName)$randomIdentifier" `
-            --image $vmImage `
-            --public-ip-sku $publicIpSku `
-            --admin-username $adminUser `
-            --admin-password "$($adminPassword)$randomIdentifier"
+        "creating VM $($vmName)$randomIdentifier in Vnet $($vnetName)$randomIdentifier in RG $existingRgName" >> $logFileLocation
+        $adminPassword = "myAdminPassword$randomIdentifier"
+        $vmConfig = New-AzVMConfig -VMName "$($vmName)$randomIdentifier" -VMSize "Standard_D2s_v3"
+        $vmConfig = Set-AzVMOperatingSystem -VM $vmConfig -Windows -ComputerName "$($vmName)$randomIdentifier" -Credential (New-Object System.Management.Automation.PSCredential ($adminUser, (ConvertTo-SecureString $adminPassword -AsPlainText -Force)))
+        $vmConfig = Set-AzVMSourceImage -VM $vmConfig -PublisherName "MicrosoftWindowsServer" -Offer "WindowsServer" -Skus $vmImage -Version "latest"
+        $vmConfig = Add-AzVMNetworkInterface -VM $vmConfig -Id $vnet.Subnets[0].Id -PublicIpAddressId (New-AzPublicIpAddress -ResourceGroupName $existingRgName -Location $location -AllocationMethod Static -SKU $publicIpSku).Id
+        New-AzVM -ResourceGroupName $existingRgName -Location $location -VM $vmConfig
+        "VM $($vmName)$randomIdentifier creation complete" >> $logFileLocation
+    }
+    else {
+        $vmName = "myVmName"
+        "creating VM $($vmName)$randomIdentifier in RG $existingRgName" >> $logFileLocation
+        $adminPassword = "myAdminPassword$randomIdentifier"
+        $vmConfig = New-AzVMConfig -VMName "$($vmName)$randomIdentifier" -VMSize "Standard_D2s_v3"
+        $vmConfig = Set-AzVMOperatingSystem -VM $vmConfig -Windows -ComputerName "$($vmName)$randomIdentifier" -Credential (New-Object System.Management.Automation.PSCredential ($adminUser, (ConvertTo-SecureString $adminPassword -AsPlainText -Force)))
+        $vmConfig = Set-AzVMSourceImage -VM $vmConfig -PublisherName "MicrosoftWindowsServer" -Offer "WindowsServer" -Skus $vmImage -Version "latest"
+        $vmConfig = Add-AzVMNetworkInterface -VM $vmConfig -Id (New-AzPublicIpAddress -ResourceGroupName $existingRgName -Location $location -AllocationMethod Static -SKU $publicIpSku).Id
+        New-AzVM -ResourceGroupName $existingRgName -Location $location -VM $vmConfig
+        "VM $($vmName)$randomIdentifier creation complete" >> $logFileLocation
     }
 }
+
+# Read your log file
+Get-Content $logFileLocation
 # </FullScript>

--- a/azure-cli/create-azure-resources-at-scale/powershell/create-azure-resources-at-scale.ps1
+++ b/azure-cli/create-azure-resources-at-scale/powershell/create-azure-resources-at-scale.ps1
@@ -1,41 +1,160 @@
-# Run this script in Azure Cloud Shell, PowerShell environment, or PowerShell 7
-# Passed validation in Azure Cloud Shell, PowerShell environment, on 4/25/2024
+# Passed validation in Ubuntu 22.04.3 LTS on 4/29/2024
 
 # <VariableBlock>
 # Variable block
-$subscriptionID=00000000-0000-0000-0000-00000000
-$setupFileLocation="myFilePath\myFileName.csv"
-$logFileLocation="myFilePath\myLogName.txt"
+$subscriptionID = "00000000-0000-0000-0000-00000000"
+$setupFileLocation = "myFilePath\myFileName.csv"
+$logFileLocation = "myFilePath\myLogName.txt"
 
 # These variables are placeholders whose values are replaced from the csv input file, or appended to a random ID.
-$location=""
-$createRG=""
-$newRgName="msdocs-rg-"
-$existingRgName=""
-$createVnet=""
+$location = ""
+$createRG = ""
+$newRgName = "msdocs-rg-"
+$existingRgName = ""
+$createVnet = ""
 
-$vmName="msdocs-vm-"
-$vmImage=""
-$publicIpSku=""
-$adminUser=""
-$adminPassword="msdocs-pw-"
+$vmName = "msdocs-vm-"
+$vmImage = ""
+$publicIpSku = ""
+$adminUser = ""
+$adminPassword = "msdocs-pw-"
 
-$vnetName="msdocs-vnet-"
-$subnetName="msdocs-subnet-"
-$vnetAddressPrefix=""
-$subnetAddressPrefix=""
+$vnetName = "msdocs-vnet-"
+$subnetName = "msdocs-subnet-"
+$vnetAddressPrefix = ""
+$subnetAddressPrefix = ""
 
-# set azure subscription 
-az account set --subscription $subscriptionID
+# Set Azure subscription
+Set-AzContext -SubscriptionId $subscriptionID
 # </VariableBlock>
 
 # <ValidateFileValues>
+#Skip the header line
+$csvData = Import-Csv -Path $setupFileLocation | Select-Object -Skip 1
+foreach ($row in $csvData) {
+    $randomIdentifier = [int]([math]::Abs([System.Random]::new().Next()))
+    $resourceNo = $row.resourceNo
+    $location = $row.location
+    $createRG = $row.createRG
+    $existingRgName = $row.existingRgName
+    $createVnet = $row.createVnet
+    $vmImage = $row.vmImage
+    $publicIpSku = $row.publicIpSku
+    $adminUser = $row.adminUser
+    $vnetAddressPrefix = $row.vnetAddressPrefix
+    $subnetAddressPrefix = $row.subnetAddressPrefix
+
+    Write-Host "resourceNo = $resourceNo"
+    Write-Host "location = $location"
+    Write-Host ""
+
+    Write-Host "RESOURCE GROUP INFORMATION:"
+    Write-Host "createRG = $createRG"
+    if ($createRG -eq "TRUE") {
+        Write-Host "newRGName = $newRgName$randomIdentifier"
+    }
+    else {
+        Write-Host "existingRgName = $existingRgName"
+    }
+    Write-Host ""
+
+    Write-Host "VNET INFORMATION:"
+    Write-Host "createVnet = $createVnet"
+    if ($createVnet -eq "TRUE") {
+        Write-Host "vnetName = $vnetName$randomIdentifier"
+        Write-Host "subnetName = $subnetName$randomIdentifier"
+        Write-Host "vnetAddressPrefix = $vnetAddressPrefix"
+        Write-Host "subnetAddressPrefix = $subnetAddressPrefix"
+    }
+    Write-Host ""
+
+    Write-Host "VM INFORMATION:"
+    Write-Host "vmName = $vmName$randomIdentifier"
+    Write-Host "vmImage = $vmImage"
+    Write-Host "vmSku = $publicIpSku"
+    Write-Host "vmAdminUser = $adminUser"
+    Write-Host "vmAdminPassword = $adminPassword$randomIdentifier"
+}
 # </ValidateFileValues>
 
-
 # <ValidateScriptLogic>
+# Validate script logic
+Write-Output "Validating script" | Out-File -FilePath $logFileLocation
+
+#Skip the header line
+$csvData = Import-Csv -Path $setupFileLocation | Select-Object -Skip 1
+foreach ($row in $csvData) {
+    $resourceNo = $row.resourceNo
+    $randomIdentifier = [int]([math]::Abs([System.Random]::new().Next()))
+    $createRG = $row.createRG
+    $createVnet = $row.createVnet
+
+    Write-Output "resourceNo = $resourceNo" | Out-File -FilePath $logFileLocation -Append
+    if ($createRG -eq "TRUE") {
+        Write-Output "creating RG $newRgName$randomIdentifier" | Out-File -FilePath $logFileLocation -Append
+        $existingRgName = "$newRgName$randomIdentifier"
+    }
+    if ($createVnet -eq "TRUE") {
+        Write-Output "creating VNet $vnetName$randomIdentifier in RG $existingRgName" | Out-File -FilePath $logFileLocation -Append
+        Write-Output "creating VM $vmName$randomIdentifier within Vnet $vnetName$randomIdentifier in RG $existingRgName" | Out-File -FilePath $logFileLocation -Append
+    }
+    else {
+        Write-Output "creating VM $vmName$randomIdentifier without Vnet in RG $existingRgName" | Out-File -FilePath $logFileLocation -Append
+    }
+
+    # Read your log file
+    Clear-Host
+    Get-Content -Path $logFileLocation
+}
+
 # </ValidateScriptLogic>
 
-
 # <FullScript>
+# create Azure resources
+$logFileLocation = "C:\path\to\log.txt"
+$setupFileLocation = "C:\path\to\setup.csv"
+
+#Skip the header line
+Get-Content $setupFileLocation | Select-Object -Skip 1 | ForEach-Object {
+    $resourceNo, $location, $createRG, $existingRgName, $createVnet, $vmImage, $publicIpSku, $adminUser, $vnetAddressPrefix, $subnetAddressPrefix = $_ -split ','
+
+    Add-Content $logFileLocation "resourceNo = $resourceNo"
+
+    $randomIdentifier = (Get-Random) * (Get-Random)
+
+    if ($createRG -eq "TRUE") {
+        Add-Content $logFileLocation "creating RG $($newRgName)$randomIdentifier"
+        az group create --location $location --name $($newRgName)$randomIdentifier
+        $existingRgName = "$($newRgName)$randomIdentifier"
+    }
+
+    if ($createVnet -eq "TRUE") {
+        Add-Content $logFileLocation "creating VNet $($vnetName)$randomIdentifier in RG $existingRgName"
+        az network vnet create `
+            --name "$($vnetName)$randomIdentifier" `
+            --resource-group $existingRgName `
+            --address-prefix $vnetAddressPrefix `
+            --subnet-name "$($subnetName)$randomIdentifier" `
+            --subnet-prefixes $subnetAddressPrefix
+
+        Add-Content $logFileLocation "creating VM $($vmName)$randomIdentifier within Vnet $($vnetName)$randomIdentifier in RG $existingRgName"
+        az vm create `
+            --resource-group $existingRgName `
+            --name "$($vmName)$randomIdentifier" `
+            --image $vmImage `
+            --vnet-name "$($vnetName)$randomIdentifier" `
+            --public-ip-sku $publicIpSku `
+            --admin-username $adminUser `
+            --admin-password "$($adminPassword)$randomIdentifier"
+    } else {
+        Add-Content $logFileLocation "creating VM $($vmName)$randomIdentifier without Vnet in RG $existingRgName"
+        az vm create `
+            --resource-group $existingRgName `
+            --name "$($vmName)$randomIdentifier" `
+            --image $vmImage `
+            --public-ip-sku $publicIpSku `
+            --admin-username $adminUser `
+            --admin-password "$($adminPassword)$randomIdentifier"
+    }
+}
 # </FullScript>


### PR DESCRIPTION
<!--
    Thanks for contributing to the Azure CLI samples repo! For contributors, make sure that you
    fill in the PR checklist in this template, and:

    * Internal contributors: Follow the style guides and PR submission process docs:
        - CLI style guide: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-cli?branch=master
        - Best practices: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-scripts?branch=master
        - PR submission process: https://review.docs.microsoft.com/en-us/help/contribute/contribute-scripts-pr-process?branch=master

    * External contributors: Make sure that you test _all_ of your scripts that you modified. You can't read the contribution
        guides yet, but reviewer feedback will be detailed and clear about any required changes.
-->

## Description

<!-- Include a brief description of your changes. -->

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [ ] Scripts in this pull request are written for the `bash` shell.
- [ ] This pull request was tested on __at least one of__ the following platforms:
  - [ ] Linux
  - [ ] Azure Cloud Shell
  - [ ] macOS
  - [ ] Windows Subsystem for Linux
- [ ] The most recent test date and test method are recorded in the script file.
- [ ] Scripts do not contain passwords or other secret tokens that are not randomized.
- [ ] No deprecated commands or arguments are used. ([Release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli))
- [ ] All Azure resource identifiers which must be universally unique are guaranteed to be so.
- [ ] Resource names use a random function to ensure scripts can be run multiple times in quick succession without error.
- [ ] All scripts can be run in their entirely without user input.

### Testing information

CLI version:
```
az --version
```

Extensions required:
