### PR TITLE
database-auditing-and-threat-detection.sh | removed deprecated command

### DIFF
--- a/sql-database/database-auditing-and-threat-detection/database-auditing-and-threat-detection.sh
+++ b/sql-database/database-auditing-and-threat-detection/database-auditing-and-threat-detection.sh
@@ -33,6 +33,8 @@ az storage account create --name $storage --resource-group $resourceGroup --loca
 echo "Setting access policy on $storage..."
 az sql db audit-policy update --name $database --resource-group $resourceGroup --server $server --state Enabled --bsts Enabled --storage-account $storage
 
+# use `az sql db advanced-threat-protection-setting update` to set the threat detection policy on $storage
+
 # </FullScript>
 
 # echo "Deleting all resources"

--- a/sql-database/database-auditing-and-threat-detection/database-auditing-and-threat-detection.sh
+++ b/sql-database/database-auditing-and-threat-detection/database-auditing-and-threat-detection.sh
@@ -33,9 +33,6 @@ az storage account create --name $storage --resource-group $resourceGroup --loca
 echo "Setting access policy on $storage..."
 az sql db audit-policy update --name $database --resource-group $resourceGroup --server $server --state Enabled --bsts Enabled --storage-account $storage
 
-echo "Setting threat detection policy on $storage..."
-az sql db threat-policy update --email-account-admins Disabled --email-addresses $notification --name $database --resource-group $resourceGroup --server $server --state Enabled --storage-account $storage
-
 # </FullScript>
 
 # echo "Deleting all resources"


### PR DESCRIPTION
The [az sql db threat-policy update]() is implicitly deprecated because command group 'sql db threat-policy' is deprecated and will be removed in a future release. Use '[sql db advanced-threat-protection-setting](https://learn.microsoft.com/en-us/cli/azure/sql/db/advanced-threat-protection-setting?view=azure-cli-latest#az-sql-db-advanced-threat-protection-setting-update)' instead.
